### PR TITLE
feat: add IBackupExecutor interface for executing backup jobs sequentially

### DIFF
--- a/src/EasySave.Core/Interfaces/IBackupExecutor.cs
+++ b/src/EasySave.Core/Interfaces/IBackupExecutor.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasySave.Core.Interfaces
+{
+    /// <summary>
+    /// Executes one or more backup jobs sequentially.
+    /// Depends on strategies, the FileSystem, the StateWriter, and logging (injected).
+    /// Supports cooperative cancellation during execution.
+    /// </summary>
+    public interface IBackupExecutor
+    {
+        /// <summary>
+        /// Executes the backup jobs whose identifiers are provided, in order.
+        /// </summary>
+        /// <param name="jobIds">
+        /// Identifiers of the backup jobs to execute (e.g. 1, 3 or 1, 2, 3).
+        /// </param>
+        /// <param name="cancellationToken">
+        /// Token used to request cancellation of the execution.
+        /// Allows the operation to stop gracefully (for example when the user cancels
+        /// the process or the application is shutting down).
+        /// </param>
+        Task ExecuteAsync(IReadOnlyList<int> jobIds, CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
## Description

Ajout de l'interface IBackupExecutor pour executer les jobs de sauvegarde séquentiellement.

## Liens vers les issues

- Closes #23 

## Type de changement

- [ ] Nouvelle feature
- [ ] Correction de bug
- [x] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [x] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
