### PR TITLE
feat: add interfaces IBackupStrategy and IBackupStrategyFactory

### DIFF
--- a/src/EasySave.Core/Interfaces/IBackupStrategy.cs
+++ b/src/EasySave.Core/Interfaces/IBackupStrategy.cs
@@ -12,14 +12,13 @@ namespace EasySave.Core.Interfaces
     public interface IBackupStrategy
     {
         /// <summary>
-        /// Get the eligible files according to the backup type (complete or differential)
+        /// Retrieves the files eligible for backup based on the backup type (full or differential).
         /// </summary>
-        /// <param name="job"></param>
-        /// <param name="files"></param>
-        /// <param name="differentialSinceUtc"></param>
-        /// <param name="ct"></param>
-        /// <returns></returns>
-        public IAsyncEnumerable<FileItem> GetEligibleFilesAsync(BackupJob job, IAsyncEnumerable<FileItem> files,
-            DateTime? differentialSinceUtc, CancellationToken ct);
+        /// <param name="job">The backup job configuration.</param>
+        /// <param name="files">The list of source files to evaluate.</param>
+        /// <param name="differentialSinceUtc">The reference date for differential backups (UTC). Null for full backups.</param>
+        /// <param name="ct">The token used to observe cancellation requests.</param>
+        /// <returns>An asynchronous stream of files that should be included in the backup.</returns>
+        public IAsyncEnumerable<FileItem> GetEligibleFilesAsync(BackupJob job, IAsyncEnumerable<FileItem> files, DateTime? differentialSinceUtc, CancellationToken ct);
     }
 }

--- a/src/EasySave.Core/Interfaces/IBackupStrategyFactory.cs
+++ b/src/EasySave.Core/Interfaces/IBackupStrategyFactory.cs
@@ -3,15 +3,15 @@
 namespace EasySave.Core.Interfaces
 {
     /// <summary>
-    /// Returns the strategy according to the type
+    /// Provides the appropriate backup strategy based on the specified backup type.
     /// </summary>
     public interface IBackupStrategyFactory
     {
         /// <summary>
-        /// Give the strategy according to the backup type
+        /// Retrieves the backup strategy that corresponds to the given backup type.
         /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
+        /// <param name="type">The backup type used to determine which strategy to return.</param>
+        /// <returns>The corresponding <see cref="IBackupStrategy"/> implementation.</returns>
         public IBackupStrategy GetStrategy(BackupType type);
     }
 }

--- a/src/EasySave.Core/Interfaces/IConfigurationRepository.cs
+++ b/src/EasySave.Core/Interfaces/IConfigurationRepository.cs
@@ -6,33 +6,30 @@ using EasySave.Core.Entities;
 namespace EasySave.Core.Interfaces
 {
     /// <summary>
-    /// Defines the loading and saving of the configuration (list of jobs, log/status directory,
-    /// date of last full backup per job).
+    /// Defines methods for loading and saving the backup configuration,
+    /// including the list of jobs, log/status directory, and the date of the last full backup for each job.
     /// </summary>
     public interface IConfigurationRepository
     {
         /// <summary>
-        /// Load the file configuration
+        /// Loads the backup configuration from persistent storage.
         /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
         public Task LoadAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        /// Save the configuration
+        /// Saves the provided backup configuration to persistent storage.
         /// </summary>
-        /// <param name="backupConfiguration"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="backupConfiguration">The configuration data to save.</param>
+        /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
         public Task SaveAsync(BackupConfiguration backupConfiguration, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Update the date
+        /// Updates the date of the last full backup for the specified job.
         /// </summary>
-        /// <param name="jobId"></param>
-        /// <param name="utc"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Task UpdateLastFullBackuoAsync(int jobId, DateTime utc, CancellationToken cancellationToken);
+        /// <param name="jobId">The unique identifier of the job to update.</param>
+        /// <param name="utc">The date and time (in UTC) of the last full backup.</param>
+        /// <param name="cancellationToken">Token used to observe cancellation requests.</param>
+        public Task UpdateLastFullBackupAsync(int jobId, DateTime utc, CancellationToken cancellationToken);
     }
 }

--- a/src/EasySave.Core/Interfaces/IStateWriter.cs
+++ b/src/EasySave.Core/Interfaces/IStateWriter.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using EasySave.Core.Models;
+using EasySave.Core.Entities;
 
 namespace EasySave.Core.Interfaces
 {


### PR DESCRIPTION
## Description

IBackupStrategy définit le filtrage des fichiers éligibles (complète vs différentielle). IBackupStrategyFactory retourne la stratégie selon le type. Elles permettent d’étendre les types de sauvegarde sans modifier le moteur (Open/Closed).

## Liens vers les issues

- Closes #24 

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [x] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [ ] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [ ] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
