### PR TITLE
feat add DailyLogWriter for EasyLog

### DIFF
--- a/EasySave.sln
+++ b/EasySave.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyLog", "src\EasyLog\EasyLog.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
@@ -9,6 +9,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Infrastructure.Tests", "tests\EasySave.Infrastructure.Tests\EasySave.Infrastructure.Tests.csproj", "{0E94B023-C02C-4AD3-8723-55305E094D66}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyLog.Tests", "tests\EasyLog.Tests\EasyLog.Tests.csproj", "{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,12 +70,25 @@ Global
 		{0E94B023-C02C-4AD3-8723-55305E094D66}.Release|x64.Build.0 = Release|Any CPU
 		{0E94B023-C02C-4AD3-8723-55305E094D66}.Release|x86.ActiveCfg = Release|Any CPU
 		{0E94B023-C02C-4AD3-8723-55305E094D66}.Release|x86.Build.0 = Release|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Debug|x64.Build.0 = Debug|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Debug|x86.Build.0 = Debug|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Release|x64.ActiveCfg = Release|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Release|x64.Build.0 = Release|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Release|x86.ActiveCfg = Release|Any CPU
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0E94B023-C02C-4AD3-8723-55305E094D66} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E5F6A7B8-C9D0-1234-EF01-345678901234}

--- a/src/EasyLog/DailyLogWriter.cs
+++ b/src/EasyLog/DailyLogWriter.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyLog
+{
+    /// <summary>
+    /// DailyLogWriter is responsible for writing log entries to daily log files in JSON format.
+    /// Each daily file contains a single JSON array with one object per log entry.
+    /// </summary>
+    public sealed class DailyLogWriter
+    {
+        private string _baseDirectory;
+        private JsonSerializerOptions _jsonOptions;
+        private readonly SemaphoreSlim _lock = new(1,1);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DailyLogWriter"/> class.
+        /// </summary>
+        /// <param name="baseDirectory">Base directory where daily log files will be stored.</param>
+        public DailyLogWriter(string baseDirectory)
+        {
+            _baseDirectory = baseDirectory;
+            _jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+        }
+
+        /// <summary>
+        /// Writes the specified log entry asynchronously to a daily log file in JSON array format.
+        /// The file name is determined from UTC date (format: yyyy-MM-dd.json).
+        /// </summary>
+        public async Task WriteLogAsync<T>(T logEntry, CancellationToken cancellationToken = default)
+        {
+            var logFilePath = Path.Combine(_baseDirectory, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
+            Directory.CreateDirectory(_baseDirectory);
+
+            var json = JsonSerializer.Serialize(logEntry, _jsonOptions);
+
+            await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var existing = File.Exists(logFilePath)
+                    ? await Task.Run(() => File.ReadAllText(logFilePath, Encoding.UTF8), cancellationToken).ConfigureAwait(false)
+                    : string.Empty;
+                var trimmed = existing.TrimEnd();
+                var trailing = existing.Length > trimmed.Length ? existing.Substring(trimmed.Length) : string.Empty;
+
+                string newContent;
+                if (string.IsNullOrEmpty(trimmed) || trimmed == "[")
+                    newContent = "[" + json + "]" + trailing;
+                else
+                {
+                    var lastBracket = trimmed.LastIndexOf(']');
+                    newContent = lastBracket >= 0
+                        ? trimmed.Substring(0, lastBracket) + "," + json + trimmed.Substring(lastBracket) + trailing
+                        : trimmed + "," + json + "]" + trailing;
+                }
+
+                await Task.Run(() => File.WriteAllText(logFilePath, newContent, Encoding.UTF8), cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+    }
+}

--- a/tests/EasyLog.Tests/DailyLogWriterTests.cs
+++ b/tests/EasyLog.Tests/DailyLogWriterTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using EasyLog;
+
+namespace EasyLog.Tests;
+
+/// <summary>
+/// Unit tests for the <see cref="DailyLogWriter"/> class.
+/// Checks creation and appending of JSON entries in daily log files.
+/// </summary>
+public sealed class DailyLogWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public DailyLogWriterTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "EasyLogTests", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public async Task WriteLogAsync_CreatesFileWithArray_WhenMissing()
+    {
+        var writer = new DailyLogWriter(_tempDir);
+        var entry = new LogEntry(DateTime.UtcNow, "job1", "src", "dest", 123L, TimeSpan.FromMilliseconds(10));
+        await writer.WriteLogAsync(entry);
+
+        var file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
+        Assert.True(File.Exists(file));
+
+        var content = File.ReadAllText(file);
+        using (var doc = JsonDocument.Parse(content))
+        {
+            Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+            Assert.Equal(1, doc.RootElement.GetArrayLength());
+            var obj = doc.RootElement[0];
+            Assert.Equal("job1", obj.GetProperty("BackupName").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task WriteLogAsync_AppendsToExistingArray_WhenFileHasArray()
+    {
+        var file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
+        var initial = new { TimeStamp = DateTime.UtcNow, BackupName = "initial", SourcePath = "s", DestinationPath = "d", FileSizeBytes = 1, TrasnferTimeMs = TimeSpan.FromMilliseconds(1) };
+        var initialJson = JsonSerializer.Serialize(initial, new JsonSerializerOptions { WriteIndented = true });
+        File.WriteAllText(file, "[" + initialJson + "]");
+
+        var writer = new DailyLogWriter(_tempDir);
+        var entry = new LogEntry(DateTime.UtcNow, "appended", "src2", "dest2", 456L, TimeSpan.FromMilliseconds(20));
+        await writer.WriteLogAsync(entry);
+
+        var content = File.ReadAllText(file);
+        using (var doc = JsonDocument.Parse(content))
+        {
+            Assert.Equal(2, doc.RootElement.GetArrayLength());
+            Assert.Equal("appended", doc.RootElement[1].GetProperty("BackupName").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task WriteLogAsync_PreservesTrailingWhitespace_WhenFileContainsOnlyOpeningBracket()
+    {
+        var file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
+        var trailing = "\r\n\r\n";
+        File.WriteAllText(file, "[" + trailing);
+
+        var writer = new DailyLogWriter(_tempDir);
+        var entry = new LogEntry(DateTime.UtcNow, "onlyBracket", "s", "d", 2, TimeSpan.Zero);
+        await writer.WriteLogAsync(entry);
+
+        var content = File.ReadAllText(file);
+        using (var doc = JsonDocument.Parse(content))
+        {
+            Assert.Equal(1, doc.RootElement.GetArrayLength());
+            Assert.Equal("onlyBracket", doc.RootElement[0].GetProperty("BackupName").GetString());
+        }
+        Assert.EndsWith(trailing, content);
+    }
+
+    [Fact]
+    public async Task WriteLogAsync_ConcurrentWrites_ProducesAllEntries()
+    {
+        var writer = new DailyLogWriter(_tempDir);
+        var n = 10;
+        var tasks = Enumerable.Range(0, n).Select(i =>
+        {
+            var entry = new LogEntry(DateTime.UtcNow, "job" + i, "s", "d", i, TimeSpan.FromMilliseconds(i));
+            return writer.WriteLogAsync(entry);
+        }).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
+        var content = File.ReadAllText(file);
+        using (var doc = JsonDocument.Parse(content))
+        {
+            Assert.Equal(n, doc.RootElement.GetArrayLength());
+            var names = doc.RootElement.EnumerateArray().Select(e => e.GetProperty("BackupName").GetString()).ToArray();
+            for (var i = 0; i < n; i++)
+                Assert.Contains("job" + i, names);
+        }
+    }
+}

--- a/tests/EasyLog.Tests/EasyLog.Tests.csproj
+++ b/tests/EasyLog.Tests/EasyLog.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EasyLog\EasyLog.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Description

DailyLogWriter implémente ILogWriter et enregistre les logs dans un répertoire injecté (pas de chemin en dur). Le constructeur reçoit le répertoire de base et initialise les options JSON et le sémaphore.

## Liens vers les issues

- Closes #41 

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [ ] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
