### PR TITLE
feat: add ShouldRunTui method with tests for command-line argument handling

### DIFF
--- a/src/EasySave.Console/Cli/CommandLineParser.cs
+++ b/src/EasySave.Console/Cli/CommandLineParser.cs
@@ -13,6 +13,20 @@ namespace EasySave.Console.Cli
     /// </summary>
     public static class CommandLineParser
     {
+        /// <summary>
+        /// Indicates whether the application should start the TUI (no arguments or first argument is --tui).
+        /// </summary>
+        /// <param name="args">Command-line arguments.</param>
+        /// <returns>
+        /// True to start the TUI, false to run in CLI mode (e.g. EasySave 1-3).
+        /// </returns>
+        public static bool ShouldRunTui(string[]? args)
+        {
+            if (args == null || args.Length == 0)
+                return true;
+            return args.Length >= 1 && string.Equals(args[0], "--tui", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static IReadOnlyList<int> Parse(string[] args)
         {
             if (args == null || args.Length == 0)

--- a/tests/EasySave.Console.Tests/CommandLineParserTests.cs
+++ b/tests/EasySave.Console.Tests/CommandLineParserTests.cs
@@ -6,6 +6,50 @@ namespace EasySave.Console.Tests {
 
 public sealed class CommandLineParserTests
 {
+    // --- ShouldRunTui tests ---
+
+    [Fact]
+    public void ShouldRunTui_ReturnsTrue_WhenArgsAreNull()
+    {
+        bool result = CommandLineParser.ShouldRunTui(null);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldRunTui_ReturnsTrue_WhenNoArgs()
+    {
+        string[] args = { };
+
+        bool result = CommandLineParser.ShouldRunTui(args);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ShouldRunTui_ReturnsTrue_WhenFirstArgIsTui_CaseInsensitive()
+    {
+        string[] argsLower = { "--tui" };
+        string[] argsUpper = { "--TUI" };
+        string[] argsMixed = { "--TuI" };
+
+        Assert.True(CommandLineParser.ShouldRunTui(argsLower));
+        Assert.True(CommandLineParser.ShouldRunTui(argsUpper));
+        Assert.True(CommandLineParser.ShouldRunTui(argsMixed));
+    }
+
+    [Fact]
+    public void ShouldRunTui_ReturnsFalse_WhenFirstArgIsNotTui()
+    {
+        string[] args = { "1-3" };
+
+        bool result = CommandLineParser.ShouldRunTui(args);
+
+        Assert.False(result);
+    }
+
+    // --- Parse tests ---
+
     [Fact]
     public void Parse_ReturnsEmptyList_WhenNoArgs()
     {


### PR DESCRIPTION
## Description

Ajout de la fonction ShouldRunTui qui permet de savoir si l'on doit lancer le Text User Interface ou le CLI.

## Liens vers les issues

- Closes #99 

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [x] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
