### PR TITLE
refactor: add message in different languages

### DIFF
--- a/src/EasySave.Console/Program.cs
+++ b/src/EasySave.Console/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EasySave.Console.Cli;
+using EasySave.Console.Resources;
 using EasySave.Core.Interfaces;
 using EasySave.ConsoleApp;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,7 +17,7 @@ class Program
 
         if (!jobIds.Any())
         {
-            string usage = "Usage: EasySave.exe <jobIds> (ex: 1-3 ou 1;3;5)";
+            string usage = $"{LangHelper.GetString("UsageJob")}";
             Console.WriteLine(usage);
             return;
         }
@@ -34,21 +35,21 @@ class Program
             cts.Cancel();
         };
 
-        Console.WriteLine($"EasySave console initialized with base path: {basePath}");
-        Console.WriteLine($"Executing jobs: {string.Join(", ", jobIds)}");
+        Console.WriteLine($"{LangHelper.GetString("ConsoleInitialized")}: {basePath}");
+        Console.WriteLine($"{LangHelper.GetString("ExecutingJobs")}: {string.Join(", ", jobIds)}");
 
         try
         {
             await executor.ExecuteAsync(jobIds, cts.Token);
-            Console.WriteLine("Backup jobs completed successfully."); 
+            Console.WriteLine(LangHelper.GetString("BackupSuccess")); 
         }
         catch (OperationCanceledException)
         {
-            Console.WriteLine("Backup cancelled by user (Ctrl+C)."); 
+            Console.WriteLine(LangHelper.GetString("BackupCancelled")); 
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Backup failed: {ex.Message}"); 
+            Console.WriteLine($"{LangHelper.GetString("BackupError")}: {ex.Message}"); 
         }
     }
 }

--- a/src/EasySave.Console/Resources/Strings.Designer.cs
+++ b/src/EasySave.Console/Resources/Strings.Designer.cs
@@ -60,7 +60,7 @@ namespace EasySave.Console.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cancel the backup..
+        ///   Looks up a localized string similar to Cancel the backup (Ctrl+C)..
         /// </summary>
         internal static string BackupCancel {
             get {
@@ -114,11 +114,29 @@ namespace EasySave.Console.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Backup success..
+        /// </summary>
+        internal static string BackupSucess {
+            get {
+                return ResourceManager.GetString("BackupSucess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Select the backup type..
         /// </summary>
         internal static string BackupTypeSelect {
             get {
                 return ResourceManager.GetString("BackupTypeSelect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to EasySave console initialized with base path.
+        /// </summary>
+        internal static string ConsoleInitialized {
+            get {
+                return ResourceManager.GetString("ConsoleInitialized", resourceCulture);
             }
         }
         
@@ -137,6 +155,15 @@ namespace EasySave.Console.Resources {
         internal static string English {
             get {
                 return ResourceManager.GetString("English", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Executing jobs.
+        /// </summary>
+        internal static string ExecutingJobs {
+            get {
+                return ResourceManager.GetString("ExecutingJobs", resourceCulture);
             }
         }
         
@@ -186,11 +213,29 @@ namespace EasySave.Console.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Usage {
+            get {
+                return ResourceManager.GetString("Usage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please select a number between 1 and 3..
         /// </summary>
         internal static string UsageHint {
             get {
                 return ResourceManager.GetString("UsageHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Usage: EasySave.exe &lt;jobIds&gt; (e.g., 1-3 or 1;3;5).
+        /// </summary>
+        internal static string UsageJob {
+            get {
+                return ResourceManager.GetString("UsageJob", resourceCulture);
             }
         }
     }

--- a/src/EasySave.Console/Resources/Strings.fr.Designer.cs
+++ b/src/EasySave.Console/Resources/Strings.fr.Designer.cs
@@ -60,7 +60,7 @@ namespace EasySave.Console.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Annuler la sauvegarde..
+        ///   Looks up a localized string similar to Annuler la sauvegarde (Ctrl+C)..
         /// </summary>
         internal static string BackupCancel {
             get {
@@ -114,11 +114,29 @@ namespace EasySave.Console.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sauvegardee réussite..
+        /// </summary>
+        internal static string BackupSucess {
+            get {
+                return ResourceManager.GetString("BackupSucess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sélectionner le type de sauvegarde..
         /// </summary>
         internal static string BackupTypeSelect {
             get {
                 return ResourceManager.GetString("BackupTypeSelect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Console EasySave initialisée avec le chemin de base.
+        /// </summary>
+        internal static string ConsoleInitialized {
+            get {
+                return ResourceManager.GetString("ConsoleInitialized", resourceCulture);
             }
         }
         
@@ -137,6 +155,15 @@ namespace EasySave.Console.Resources {
         internal static string English {
             get {
                 return ResourceManager.GetString("English", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Travail en cours..
+        /// </summary>
+        internal static string ExecutingJobs {
+            get {
+                return ResourceManager.GetString("ExecutingJobs", resourceCulture);
             }
         }
         
@@ -191,6 +218,15 @@ namespace EasySave.Console.Resources {
         internal static string UsageHint {
             get {
                 return ResourceManager.GetString("UsageHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Utilisation : EasySave.exe &lt;jobIds&gt; (ex : 1-3 ou 1;3;5).
+        /// </summary>
+        internal static string UsageJob {
+            get {
+                return ResourceManager.GetString("UsageJob", resourceCulture);
             }
         }
     }

--- a/src/EasySave.Console/Resources/Strings.fr.resx
+++ b/src/EasySave.Console/Resources/Strings.fr.resx
@@ -34,7 +34,7 @@
         <value>Démarrer la sauvegarde.</value>
     </data>
     <data name="BackupCancel" xml:space="preserve">
-        <value>Annuler la sauvegarde.</value>
+        <value>Annuler la sauvegarde (Ctrl+C).</value>
     </data>
     <data name="FullBackup" xml:space="preserve">
         <value>Sauvegarde complète.</value>
@@ -62,5 +62,17 @@
     </data>
     <data name="BackupStrategyError" xml:space="preserve">
         <value>Il y a une erreur dans le choix de la sauvegarde.</value>
+    </data>
+    <data name="BackupSucess" xml:space="preserve">
+        <value>Sauvegardee réussite.</value>
+    </data>
+    <data name="ExecutingJobs" xml:space="preserve">
+        <value>Travail en cours.</value>
+    </data>
+    <data name="ConsoleInitialized" xml:space="preserve">
+        <value>Console EasySave initialisée avec le chemin de base</value>
+    </data>
+    <data name="UsageJob" xml:space="preserve">
+        <value>Utilisation : EasySave.exe &lt;jobIds&gt; (ex : 1-3 ou 1;3;5)</value>
     </data>
 </root>

--- a/src/EasySave.Console/Resources/Strings.resx
+++ b/src/EasySave.Console/Resources/Strings.resx
@@ -34,7 +34,7 @@
         <value>Start the backup.</value>
     </data>
     <data name="BackupCancel" xml:space="preserve">
-        <value>Cancel the backup.</value>
+        <value>Cancel the backup (Ctrl+C).</value>
     </data>
     <data name="FullBackup" xml:space="preserve">
         <value>Full backup.</value>
@@ -62,5 +62,20 @@
     </data>
     <data name="BackupStrategyError" xml:space="preserve">
         <value>There is an error in the backup selection.</value>
+    </data>
+    <data name="BackupSucess" xml:space="preserve">
+        <value>Backup success.</value>
+    </data>
+    <data name="ExecutingJobs" xml:space="preserve">
+        <value>Executing jobs</value>
+    </data>
+    <data name="ConsoleInitialized" xml:space="preserve">
+        <value>EasySave console initialized with base path</value>
+    </data>
+    <data name="Usage" xml:space="preserve">
+        <value />
+    </data>
+    <data name="UsageJob" xml:space="preserve">
+        <value>Usage: EasySave.exe &lt;jobIds&gt; (e.g., 1-3 or 1;3;5)</value>
     </data>
 </root>


### PR DESCRIPTION
## Description

Aucun message affiché à l’utilisateur ne doit être en dur dans le code. Tous doivent passer par les ressources (Strings.UsageHint, Strings.BackupCompleted, Strings.BackupError, etc.) pour garantir l’i18n.

## Liens vers les issues

- Closes #97

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [x] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
