### PR TITLE
feat: add options to exclude file extensions and directory names during backup enumeration

### DIFF
--- a/src/EasySave.Console/Resources/Strings.fr.resx
+++ b/src/EasySave.Console/Resources/Strings.fr.resx
@@ -165,4 +165,10 @@ Lors de l'exécution de sauvegardes, vous pouvez spécifier les IDs des travaux 
   <data name="TuiNavigationHint" xml:space="preserve">
     <value>Flèches : déplacer | Entrée/Espace : valider | Échap : quitter | 1-4 / 0 / q : sélection numérique</value>
   </data>
+  <data name="ExcludeExtensionsPrompt" xml:space="preserve">
+    <value>Exclure des extensions de fichiers (séparées par des virgules, exemple: .tmp,.log). Vide pour aucune :</value>
+  </data>
+  <data name="ExcludeDirectoryNamesPrompt" xml:space="preserve">
+    <value>Exclure des dossiers (séparés par des virgules, exemple node_modules,.git). Vide pour aucun :</value>
+  </data>
 </root>

--- a/src/EasySave.Console/Resources/Strings.resx
+++ b/src/EasySave.Console/Resources/Strings.resx
@@ -165,4 +165,10 @@ When running backups, you can specify job IDs as :
   <data name="TuiNavigationHint" xml:space="preserve">
     <value>Arrows: move | Enter/Space: validate | Esc: quit | 1-4 / 0 / q: numeric selection</value>
   </data>
+  <data name="ExcludeExtensionsPrompt" xml:space="preserve">
+    <value>Exclude file extensions (comma-separated, example .tmp,.log). Leave empty for none:</value>
+  </data>
+  <data name="ExcludeDirectoryNamesPrompt" xml:space="preserve">
+    <value>Exclude directory names (comma-separated, example node_modules,.git). Leave empty for none:</value>
+  </data>
 </root>

--- a/src/EasySave.Console/Tui/TuiRunner.cs
+++ b/src/EasySave.Console/Tui/TuiRunner.cs
@@ -336,6 +336,15 @@ namespace EasySave.Console.Tui
             System.Console.WriteLine($"{prefix} {number}. {text}");
         }
 
+        private static List<string> ParseCommaSeparatedList(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input)) return new List<string>();
+            return input!.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => s.Trim())
+                .Where(s => s.Length > 0)
+                .ToList();
+        }
+
         private static async Task CreateJobAsync(IConfigurationRepository configRepository)
         {
             System.Console.WriteLine();
@@ -401,13 +410,26 @@ namespace EasySave.Console.Tui
 
             BackupType backupType = ReadBackupType();
 
+            string? extPrompt = LangHelper.GetString("ExcludeExtensionsPrompt");
+            System.Console.WriteLine();
+            System.Console.Write(extPrompt ?? "Exclude file extensions (comma-separated, example .tmp,.log). Leave empty for none: ");
+            string? extInput = System.Console.ReadLine()?.Trim();
+            List<string> excludeExtensions = ParseCommaSeparatedList(extInput);
+
+            string? dirPrompt = LangHelper.GetString("ExcludeDirectoryNamesPrompt");
+            System.Console.Write(dirPrompt ?? "Exclude file extensions (comma-separated, example .tmp,.log). Leave empty for none: ");
+            string? dirInput = System.Console.ReadLine()?.Trim();
+            List<string> excludeDirectoryNames = ParseCommaSeparatedList(dirInput);
+
             BackupJob newJob = new BackupJob
             {
                 Id = newJobId,
                 Name = name,
                 SourcePath = sourcePath,
                 TargetPath = targetPath,
-                Type = backupType
+                Type = backupType,
+                ExcludeExtensions = excludeExtensions,
+                ExcludeDirectoryNames = excludeDirectoryNames
             };
 
             jobs.Add(newJob);

--- a/src/EasySave.Core/Entities/BackupJob.cs
+++ b/src/EasySave.Core/Entities/BackupJob.cs
@@ -1,4 +1,5 @@
-﻿using EasySave.Core.Enums;
+using System.Collections.Generic;
+using EasySave.Core.Enums;
 
 namespace EasySave.Core.Entities
 {
@@ -9,17 +10,27 @@ namespace EasySave.Core.Entities
     {
         ///<summary>Unique job identifier ranging from 1 to 5</summary>
         public int Id { get; set; }
-    
+
         ///<summary>Name of the backup</summary>
         public string Name { get; set; } = string.Empty;
-    
+
         ///<summary>Source directory</summary>
         public string SourcePath { get; set; } = string.Empty;
-    
-        ///<summary>Target directoy</summary>
-        public string TargetPath { get; set; } = string.Empty;  
-    
+
+        ///<summary>Target directory</summary>
+        public string TargetPath { get; set; } = string.Empty;
+
         ///<summary>Type of backup</summary>
         public BackupType Type { get; set; }
+
+        /// <summary>
+        /// File extensions to exclude from the backup (e.g. .tmp, .log).
+        /// </summary>
+        public IReadOnlyList<string> ExcludeExtensions { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Directory names to exclude from the backup, they're not traveled (e.g. node_modules, .git).
+        /// </summary>
+        public IReadOnlyList<string> ExcludeDirectoryNames { get; set; } = new List<string>();
     }
 }

--- a/src/EasySave.Core/Interfaces/IFileSystemService.cs
+++ b/src/EasySave.Core/Interfaces/IFileSystemService.cs
@@ -15,11 +15,13 @@ namespace EasySave.Core.Interfaces
         /// <summary>
         /// Recursively enumerates all files in a source directory.
         /// Returns an async stream to process files one by one without loading everything into memory.
+        /// When <paramref name="options"/> is provided, files with excluded extensions are omitted and excluded directory names are not traversed.
         /// </summary>
         /// <param name="sourcePath">The root directory path to scan.</param>
+        /// <param name="options">Optional enumeration options of exclude extensions and directory names.</param>
         /// <param name="cancellationToken">Token to cancel the enumeration operation.</param>
         /// <returns>An async stream of <see cref="FileItem"/>.</returns>
-        IAsyncEnumerable<FileItem> EnumerateFilesAsync(string sourcePath, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<FileItem> EnumerateFilesAsync(string sourcePath, BackupEnumerationOptions? options = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Asynchronously copies a single file from source to destination.

--- a/src/EasySave.Core/Models/BackupEnumerationOptions.cs
+++ b/src/EasySave.Core/Models/BackupEnumerationOptions.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace EasySave.Core.Models
+{
+    /// <summary>
+    /// Options applied during backup file enumeration.
+    /// </summary>
+    public sealed class BackupEnumerationOptions
+    {
+        /// <summary>
+        /// File extensions to exclude
+        /// </summary>
+        public IReadOnlyList<string> ExcludeExtensions { get; init; } = new List<string>();
+
+        /// <summary>
+        /// Directory names to exclude (e.g. "node_modules", ".git").
+        /// </summary>
+        public IReadOnlyList<string> ExcludeDirectoryNames { get; init; } = new List<string>();
+    }
+}

--- a/src/EasySave.Infrastructure/Backup/BackupExecutor.cs
+++ b/src/EasySave.Infrastructure/Backup/BackupExecutor.cs
@@ -8,6 +8,7 @@ using EasyLog;
 using EasySave.Core.Entities;
 using EasySave.Core.Enums;
 using EasySave.Core.Interfaces;
+using EasySave.Core.Models;
 using FileItem = EasySave.Core.Models.FileItem;
 
 namespace EasySave.Infrastructure.Backup
@@ -71,10 +72,16 @@ namespace EasySave.Infrastructure.Backup
                 IBackupStrategy strategy = _strategyFactory.GetStrategy(job.Type);
                 DateTime? differentialSince = job.Type == BackupType.Differential && config.LastFullBackupUtcByJobId.TryGetValue(job.Id, out DateTime since) ? since : null;
 
+                var enumOptions = new BackupEnumerationOptions
+                {
+                    ExcludeExtensions = job.ExcludeExtensions ?? Array.Empty<string>(),
+                    ExcludeDirectoryNames = job.ExcludeDirectoryNames ?? Array.Empty<string>()
+                };
+
                 // First pass: compute total size and file count without keeping the list in memory.
                 long totalSize = 0L;
                 int fileCount = 0;
-                IAsyncEnumerable<FileItem> pass1Stream = _fileSystem.EnumerateFilesAsync(job.SourcePath, cancellationToken);
+                IAsyncEnumerable<FileItem> pass1Stream = _fileSystem.EnumerateFilesAsync(job.SourcePath, enumOptions, cancellationToken);
                 await foreach (FileItem f in strategy.GetEligibleFilesAsync(job, pass1Stream, differentialSince, cancellationToken))
                 {
                     totalSize += _fileSystem.GetFileSize(f.FullSourcePath);
@@ -99,7 +106,7 @@ namespace EasySave.Infrastructure.Backup
                 // Second pass: stream and copy one file at a time so we never hold the full list.
                 long bytesCompleted = 0L;
                 int processedCount = 0;
-                IAsyncEnumerable<FileItem> pass2Stream = _fileSystem.EnumerateFilesAsync(job.SourcePath, cancellationToken);
+                IAsyncEnumerable<FileItem> pass2Stream = _fileSystem.EnumerateFilesAsync(job.SourcePath, enumOptions, cancellationToken);
                 await foreach (FileItem item in strategy.GetEligibleFilesAsync(job, pass2Stream, differentialSince, cancellationToken))
                 {
                     cancellationToken.ThrowIfCancellationRequested();

--- a/src/EasySave.Infrastructure/FileSystem/FileSystemService.cs
+++ b/src/EasySave.Infrastructure/FileSystem/FileSystemService.cs
@@ -25,7 +25,7 @@ namespace EasySave.Infrastructure.FileSystem
         {
             var fullPath = Path.GetFullPath(path);
             if (fullPath.StartsWith(@"\\", StringComparison.Ordinal))
-                return fullPath; // déjà UNC
+                return fullPath;
 
             var drive = Path.GetPathRoot(fullPath);
             if (string.IsNullOrEmpty(drive) || drive.Length < 2)
@@ -39,10 +39,13 @@ namespace EasySave.Infrastructure.FileSystem
             return fullPath;
         }
 
-        public async IAsyncEnumerable<FileItem> EnumerateFilesAsync(string sourcePath, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<FileItem> EnumerateFilesAsync(string sourcePath, BackupEnumerationOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             if (!Directory.Exists(sourcePath))
                 yield break;
+
+            var excludeExtensions = BuildExcludeExtensionsSet(options?.ExcludeExtensions);
+            var excludeDirNames = BuildExcludeDirectoryNamesSet(options?.ExcludeDirectoryNames);
 
             var stack = new Stack<string>();
             stack.Push(sourcePath);
@@ -55,6 +58,12 @@ namespace EasySave.Infrastructure.FileSystem
                 foreach (var file in Directory.EnumerateFiles(current))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    if (excludeExtensions != null)
+                    {
+                        var ext = Path.GetExtension(file);
+                        if (!string.IsNullOrEmpty(ext) && excludeExtensions.Contains(ext))
+                            continue;
+                    }
                     string relativePath = Path.GetRelativePath(sourcePath, file);
                     DateTime lastWriteUtc = File.GetLastWriteTimeUtc(file);
                     yield return new FileItem(relativePath, file, lastWriteUtc);
@@ -63,11 +72,43 @@ namespace EasySave.Infrastructure.FileSystem
                 foreach (var dir in Directory.EnumerateDirectories(current))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+                    if (excludeDirNames != null)
+                    {
+                        var dirName = Path.GetFileName(dir);
+                        if (!string.IsNullOrEmpty(dirName) && excludeDirNames.Contains(dirName, StringComparer.OrdinalIgnoreCase))
+                            continue;
+                    }
                     stack.Push(dir);
                 }
             }
 
             await Task.CompletedTask.ConfigureAwait(false);
+        }
+
+        private static HashSet<string>? BuildExcludeExtensionsSet(IReadOnlyList<string>? list)
+        {
+            if (list == null || list.Count == 0) return null;
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var s in list)
+            {
+                var t = (s ?? "").Trim();
+                if (string.IsNullOrEmpty(t)) continue;
+                if (!t.StartsWith(".", StringComparison.Ordinal)) t = "." + t;
+                set.Add(t);
+            }
+            return set.Count == 0 ? null : set;
+        }
+
+        private static HashSet<string>? BuildExcludeDirectoryNamesSet(IReadOnlyList<string>? list)
+        {
+            if (list == null || list.Count == 0) return null;
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var s in list)
+            {
+                var t = (s ?? "").Trim();
+                if (!string.IsNullOrEmpty(t)) set.Add(t);
+            }
+            return set.Count == 0 ? null : set;
         }
 
         public long GetFileSize(string path)

--- a/src/EasySave.Infrastructure/Persistence/JsonConfigurationRepository.cs
+++ b/src/EasySave.Infrastructure/Persistence/JsonConfigurationRepository.cs
@@ -1,4 +1,4 @@
-﻿using EasySave.Core.Entities;
+using EasySave.Core.Entities;
 using EasySave.Core.Interfaces;
 
 using System.Text.Json;
@@ -73,7 +73,9 @@ namespace EasySave.Infrastructure.Persistence
                 TargetPath = j.TargetPath ?? "",
                 Type = string.Equals(j.Type, "Differential", StringComparison.OrdinalIgnoreCase)
                     ? Core.Enums.BackupType.Differential
-                    : Core.Enums.BackupType.Full
+                    : Core.Enums.BackupType.Full,
+                ExcludeExtensions = j.ExcludeExtensions ?? new List<string>(),
+                ExcludeDirectoryNames = j.ExcludeDirectoryNames ?? new List<string>()
             }).ToList() ?? new List<BackupJob>();
 
             var lastFull = dto.LastFullBackupUtcByJobId ?? new Dictionary<int, DateTime>();
@@ -108,7 +110,9 @@ namespace EasySave.Infrastructure.Persistence
                     TargetPath = j.TargetPath,
                     Type = j.Type == Core.Enums.BackupType.Differential
                         ? "Differential"
-                        : "Full"
+                        : "Full",
+                    ExcludeExtensions = j.ExcludeExtensions?.Count > 0 ? new List<string>(j.ExcludeExtensions) : null,
+                    ExcludeDirectoryNames = j.ExcludeDirectoryNames?.Count > 0 ? new List<string>(j.ExcludeDirectoryNames) : null
                 }).ToList(),
                 LastFullBackupUtcByJobId = backupConfiguration.LastFullBackupUtcByJobId
                     .ToDictionary(k => k.Key, v => v.Value)
@@ -173,6 +177,8 @@ namespace EasySave.Infrastructure.Persistence
             public string? SourcePath { get; set; }
             public string? TargetPath { get; set; }
             public string? Type { get; set; }
+            public List<string>? ExcludeExtensions { get; set; }
+            public List<string>? ExcludeDirectoryNames { get; set; }
         }
     }
 }

--- a/tests/EasySave.Console.Tests/TuiRunnerTests.cs
+++ b/tests/EasySave.Console.Tests/TuiRunnerTests.cs
@@ -104,7 +104,9 @@ public sealed class TuiRunnerTests : IDisposable
             "C:\\Source" + Environment.NewLine +
             "D:\\Target" + Environment.NewLine +
             "1" + Environment.NewLine +     // type Full
-            "0" + Environment.NewLine;      // retour menu puis quitter
+            "" + Environment.NewLine +     // exclude extensions (empty)
+            "" + Environment.NewLine +     // exclude dir names (empty)
+            "0" + Environment.NewLine;     // retour menu puis quitter
 
         using StringWriter output = new();
         System.Console.SetIn(new StringReader(input));

--- a/tests/EasySave.Infrastructure.Tests/FileSystemServiceTests.cs
+++ b/tests/EasySave.Infrastructure.Tests/FileSystemServiceTests.cs
@@ -126,7 +126,7 @@ public sealed class FileSystemServiceTests : IDisposable
     {
         var nonExistentPath = Path.Combine(_tempRoot, "nonexistent");
 
-        var result = await CollectAsync(_service.EnumerateFilesAsync(nonExistentPath, CancellationToken.None));
+        var result = await CollectAsync(_service.EnumerateFilesAsync(nonExistentPath, null, CancellationToken.None));
 
         Assert.Empty(result);
     }
@@ -143,7 +143,7 @@ public sealed class FileSystemServiceTests : IDisposable
         await File.WriteAllTextAsync(file1, "content1");
         await File.WriteAllTextAsync(file2, "content2");
 
-        var result = await CollectAsync(_service.EnumerateFilesAsync(sourceDir, CancellationToken.None));
+        var result = await CollectAsync(_service.EnumerateFilesAsync(sourceDir, null, CancellationToken.None));
 
         Assert.Equal(2, result.Count);
         var paths = result.Select(f => f.RelativePath.Replace('\\', '/')).OrderBy(p => p).ToList();
@@ -161,7 +161,7 @@ public sealed class FileSystemServiceTests : IDisposable
         await File.WriteAllTextAsync(filePath, "test");
         File.SetLastWriteTimeUtc(filePath, writeTime);
 
-        var result = await CollectAsync(_service.EnumerateFilesAsync(sourceDir, CancellationToken.None));
+        var result = await CollectAsync(_service.EnumerateFilesAsync(sourceDir, null, CancellationToken.None));
 
         var item = Assert.Single(result);
         Assert.Equal("test.txt", item.RelativePath);
@@ -181,7 +181,7 @@ public sealed class FileSystemServiceTests : IDisposable
         var count = 0;
         try
         {
-            await foreach (var _ in _service.EnumerateFilesAsync(sourceDir, cts.Token))
+            await foreach (var _ in _service.EnumerateFilesAsync(sourceDir, null, cts.Token))
             {
                 count++;
                 if (count == 3)
@@ -191,6 +191,52 @@ public sealed class FileSystemServiceTests : IDisposable
         catch (OperationCanceledException) { }
 
         Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task EnumerateFilesAsync_ExcludesFilesByExtension_WhenOptionsProvided()
+    {
+        var sourceDir = Path.Combine(_tempRoot, "source");
+        Directory.CreateDirectory(sourceDir);
+        await File.WriteAllTextAsync(Path.Combine(sourceDir, "a.txt"), "x");
+        await File.WriteAllTextAsync(Path.Combine(sourceDir, "b.tmp"), "x");
+        await File.WriteAllTextAsync(Path.Combine(sourceDir, "c.log"), "x");
+        await File.WriteAllTextAsync(Path.Combine(sourceDir, "d.txt"), "x");
+
+        var options = new BackupEnumerationOptions
+        {
+            ExcludeExtensions = new[] { ".tmp", ".log" }
+        };
+        var result = await CollectAsync(_service.EnumerateFilesAsync(sourceDir, options, CancellationToken.None));
+
+        Assert.Equal(2, result.Count);
+        var names = result.Select(f => f.RelativePath.Replace("\\", "/")).OrderBy(p => p).ToList();
+        Assert.Contains("a.txt", names);
+        Assert.Contains("d.txt", names);
+    }
+
+    [Fact]
+    public async Task EnumerateFilesAsync_DoesNotTraverseExcludedDirectoryNames_WhenOptionsProvided()
+    {
+        var sourceDir = Path.Combine(_tempRoot, "source");
+        var includedDir = Path.Combine(sourceDir, "included");
+        var nodeModules = Path.Combine(sourceDir, "node_modules");
+        Directory.CreateDirectory(includedDir);
+        Directory.CreateDirectory(nodeModules);
+        await File.WriteAllTextAsync(Path.Combine(sourceDir, "root.txt"), "x");
+        await File.WriteAllTextAsync(Path.Combine(includedDir, "sub.txt"), "x");
+        await File.WriteAllTextAsync(Path.Combine(nodeModules, "pkg.js"), "x");
+
+        var options = new BackupEnumerationOptions
+        {
+            ExcludeDirectoryNames = new[] { "node_modules" }
+        };
+        var result = await CollectAsync(_service.EnumerateFilesAsync(sourceDir, options, CancellationToken.None));
+
+        Assert.Equal(2, result.Count);
+        var paths = result.Select(f => f.RelativePath.Replace("\\", "/")).OrderBy(p => p).ToList();
+        Assert.Contains("root.txt", paths);
+        Assert.Contains("included/sub.txt", paths);
     }
 
     private static async Task<List<FileItem>> CollectAsync(IAsyncEnumerable<FileItem> source)


### PR DESCRIPTION
## Description

Ajout d'options pour exclure des fichiers et des dossiers durant la backup.

## Liens vers les issues

- Closes #121 

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [x] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
