### PR TITLE
feat: add estimated time remaining and progress reporting to backup execution

### DIFF
--- a/src/EasySave.Console/Program.cs
+++ b/src/EasySave.Console/Program.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 using EasySave.Console.Cli;
 using EasySave.Console.Tui;
 using EasySave.Console.Resources;
+using EasySave.Console;
+using EasySave.Core.Entities;
+using EasySave.Core.Enums;
 using EasySave.Core.Interfaces;
 using EasySave.ConsoleApp;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,18 +49,34 @@ class Program
         Console.WriteLine($"{LangHelper.GetString("ConsoleInitialized")}: {basePath}");
         Console.WriteLine($"{LangHelper.GetString("ExecutingJobs")}: {string.Join(", ", jobIds)}");
 
+        long lastProgressTicks = 0;
+        const int ProgressThrottleMs = 120;
+        var progress = new Progress<BackupProgress>(p =>
+        {
+            if (p?.State != BackupState.Active) return;
+            long now = Environment.TickCount64;
+            if (now - lastProgressTicks >= ProgressThrottleMs)
+            {
+                lastProgressTicks = now;
+                ProgressDisplay.WriteProgressLine(p);
+            }
+        });
+
         try
         {
-            await executor.ExecuteAsync(jobIds, cts.Token);
-            Console.WriteLine(LangHelper.GetString("BackupSuccess")); 
+            await executor.ExecuteAsync(jobIds, progress, cts.Token);
+            ProgressDisplay.ClearProgressLine();
+            Console.WriteLine(LangHelper.GetString("BackupSuccess"));
         }
         catch (OperationCanceledException)
         {
-            Console.WriteLine(LangHelper.GetString("BackupCancelled")); 
+            ProgressDisplay.ClearProgressLine();
+            Console.WriteLine(LangHelper.GetString("BackupCancelled"));
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"{LangHelper.GetString("BackupError")}: {ex.Message}"); 
+            ProgressDisplay.ClearProgressLine();
+            Console.WriteLine($"{LangHelper.GetString("BackupError")}: {ex.Message}");
         }
     }
 }

--- a/src/EasySave.Console/ProgressDisplay.cs
+++ b/src/EasySave.Console/ProgressDisplay.cs
@@ -1,0 +1,99 @@
+using System;
+using EasySave.Console.Resources;
+using EasySave.Core.Entities;
+
+namespace EasySave.Console
+{
+    /// <summary>
+    /// Renders a single progress line (bar, percent, size, ETA) for console output.
+    /// </summary>
+    public static class ProgressDisplay
+    {
+        private const int BarLength = 24;
+
+        /// <summary>
+        /// Writes one progress line to the console (overwrites current line with \r).
+        /// No-op when there is no console (e.g. in tests).
+        /// </summary>
+        public static void WriteProgressLine(BackupProgress p)
+        {
+            if (p == null) return;
+            if (!TryGetConsoleWidth(out int width)) return;
+
+            long total = p.TotalSizeBytes;
+            long completed = total > 0 ? total - p.RemainingSizeBytes : 0;
+            double percent = p.ProgressPercent;
+            string bar = BuildBar(percent);
+            string sizeStr = FormatSize(completed) + " / " + FormatSize(total);
+            string etaStr = FormatEta(p.EstimatedTimeRemainingSeconds);
+            string? etaFormat = LangHelper.GetString("ETAFormat");
+            string etaLine = string.Format(etaFormat ?? "ETA: {0}", etaStr);
+
+            string line = $"{bar} {percent:F1}% {sizeStr} {etaLine}";
+            if (line.Length < width)
+                line = line + new string(' ', width - line.Length);
+            else if (line.Length > width)
+                line = line.Substring(0, width);
+
+            try { System.Console.Write("\r" + line); } catch (System.IO.IOException) { }
+        }
+
+        /// <summary>
+        /// Clears the progress line (e.g. after completion) so the next write starts clean.
+        /// No-op when there is no console (e.g. in tests).
+        /// </summary>
+        public static void ClearProgressLine()
+        {
+            if (!TryGetConsoleWidth(out int width)) return;
+            try { System.Console.Write("\r" + new string(' ', width) + "\r"); } catch (System.IO.IOException) { }
+        }
+
+        private static bool TryGetConsoleWidth(out int width)
+        {
+            width = 80;
+            try
+            {
+                width = System.Console.BufferWidth;
+                return true;
+            }
+            catch (System.IO.IOException)
+            {
+                return false;
+            }
+        }
+
+        private static string BuildBar(double percent)
+        {
+            int filled = (int)Math.Round(BarLength * Math.Clamp(percent, 0, 100) / 100.0);
+            int empty = BarLength - filled;
+            return "[" + new string('=', filled) + new string(' ', empty) + "]";
+        }
+
+        private static string FormatSize(long bytes)
+        {
+            if (bytes < 0) return "0 B";
+            string[] units = { "B", "KB", "MB", "GB", "TB" };
+            int u = 0;
+            double v = bytes;
+            while (v >= 1024 && u < units.Length - 1) { v /= 1024; u++; }
+            return u == 0 ? $"{v:F0} {units[u]}" : $"{v:F2} {units[u]}";
+        }
+
+        private static string FormatEta(double? seconds)
+        {
+            if (seconds == null || double.IsNaN(seconds.Value) || seconds.Value < 0)
+                return LangHelper.GetString("ETANone") ?? "--";
+
+            double s = seconds.Value;
+            if (s >= 60)
+            {
+                int min = (int)(s / 60);
+                int sec = (int)Math.Round(s % 60);
+                string? fmt = LangHelper.GetString("ETAMinSec");
+                return fmt != null ? string.Format(fmt, min, sec) : $"{min} min {sec} s";
+            }
+            string? secFmt = LangHelper.GetString("ETASecondsOnly");
+            return secFmt != null ? string.Format(secFmt, (int)Math.Round(s)) : $"{(int)Math.Round(s)} s";
+        }
+    }
+}

--- a/src/EasySave.Console/Resources/Strings.fr.resx
+++ b/src/EasySave.Console/Resources/Strings.fr.resx
@@ -171,4 +171,18 @@ Lors de l'exécution de sauvegardes, vous pouvez spécifier les IDs des travaux 
   <data name="ExcludeDirectoryNamesPrompt" xml:space="preserve">
     <value>Exclure des dossiers (séparés par des virgules, exemple node_modules,.git). Vide pour aucun :</value>
   </data>
+
+  <!-- Barre de progression et ETA -->
+  <data name="ETAFormat" xml:space="preserve">
+    <value>ETA : {0}</value>
+  </data>
+  <data name="ETANone" xml:space="preserve">
+    <value>--</value>
+  </data>
+  <data name="ETAMinSec" xml:space="preserve">
+    <value>{0} min {1} s</value>
+  </data>
+  <data name="ETASecondsOnly" xml:space="preserve">
+    <value>{0} s</value>
+  </data>
 </root>

--- a/src/EasySave.Console/Resources/Strings.resx
+++ b/src/EasySave.Console/Resources/Strings.resx
@@ -171,4 +171,18 @@ When running backups, you can specify job IDs as :
   <data name="ExcludeDirectoryNamesPrompt" xml:space="preserve">
     <value>Exclude directory names (comma-separated, example node_modules,.git). Leave empty for none:</value>
   </data>
+
+  <!-- Progress bar and ETA -->
+  <data name="ETAFormat" xml:space="preserve">
+    <value>ETA: {0}</value>
+  </data>
+  <data name="ETANone" xml:space="preserve">
+    <value>--</value>
+  </data>
+  <data name="ETAMinSec" xml:space="preserve">
+    <value>{0} min {1} s</value>
+  </data>
+  <data name="ETASecondsOnly" xml:space="preserve">
+    <value>{0} s</value>
+  </data>
 </root>

--- a/src/EasySave.Console/Tui/TuiRunner.cs
+++ b/src/EasySave.Console/Tui/TuiRunner.cs
@@ -8,6 +8,7 @@ using EasySave.Core.Entities;
 using EasySave.Core.Enums;
 using EasySave.Core.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using ProgressDisplay = EasySave.Console.ProgressDisplay;
 
 namespace EasySave.Console.Tui
 {
@@ -569,19 +570,35 @@ namespace EasySave.Console.Tui
             string? backupStartMsg = LangHelper.GetString("BackupStart");
             System.Console.WriteLine(backupStartMsg ?? "Starting backup...");
 
+            long lastProgressTicks = 0;
+            const int ProgressThrottleMs = 120;
+            var progress = new Progress<BackupProgress>(p =>
+            {
+                if (p?.State != BackupState.Active) return;
+                long now = Environment.TickCount64;
+                if (now - lastProgressTicks >= ProgressThrottleMs)
+                {
+                    lastProgressTicks = now;
+                    ProgressDisplay.WriteProgressLine(p);
+                }
+            });
+
             try
             {
-                await backupExecutor.ExecuteAsync(jobIds, cts.Token);
+                await backupExecutor.ExecuteAsync(jobIds, progress, cts.Token);
+                ProgressDisplay.ClearProgressLine();
                 string? backupCompletedMsg = LangHelper.GetString("BackupCompleted");
                 System.Console.WriteLine(backupCompletedMsg ?? "Backup completed successfully.");
             }
             catch (OperationCanceledException)
             {
+                ProgressDisplay.ClearProgressLine();
                 string? backupCancelMsg = LangHelper.GetString("BackupCancel");
                 System.Console.WriteLine(backupCancelMsg ?? "Backup cancelled by user.");
             }
             catch (Exception ex)
             {
+                ProgressDisplay.ClearProgressLine();
                 string? backupErrorMsg = LangHelper.GetString("BackupError");
                 System.Console.WriteLine($"{backupErrorMsg ?? "Backup failed"}: {ex.Message}");
             }

--- a/src/EasySave.Core/Entities/BackupProgress.cs
+++ b/src/EasySave.Core/Entities/BackupProgress.cs
@@ -1,4 +1,4 @@
-﻿using EasySave.Core.Enums;
+using EasySave.Core.Enums;
 using System;
 
 namespace EasySave.Core.Entities
@@ -37,5 +37,8 @@ namespace EasySave.Core.Entities
 
         /// <summary>Full path of the current destination file (if active).</summary>
         public string? CurrentDestinationPath { get; set; }
+
+        /// <summary>Estimated time remaining in seconds.</summary>
+        public double? EstimatedTimeRemainingSeconds { get; set; }
     }
 }

--- a/src/EasySave.Core/Interfaces/IBackupExecutor.cs
+++ b/src/EasySave.Core/Interfaces/IBackupExecutor.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EasySave.Core.Entities;
 
 namespace EasySave.Core.Interfaces
 {
@@ -17,11 +19,12 @@ namespace EasySave.Core.Interfaces
         /// <param name="jobIds">
         /// Identifiers of the backup jobs to execute (e.g. 1, 3 or 1, 2, 3).
         /// </param>
+        /// <param name="progress">Optional. Reports current backup progress (for real-time progress bar and ETA).</param>
         /// <param name="cancellationToken">
         /// Token used to request cancellation of the execution.
         /// Allows the operation to stop gracefully (for example when the user cancels
         /// the process or the application is shutting down).
         /// </param>
-        Task ExecuteAsync(IReadOnlyList<int> jobIds, CancellationToken cancellationToken = default);
+        Task ExecuteAsync(IReadOnlyList<int> jobIds, IProgress<BackupProgress>? progress = null, CancellationToken cancellationToken = default);
     }
 }

--- a/src/EasySave.Core/Interfaces/IFileSystemService.cs
+++ b/src/EasySave.Core/Interfaces/IFileSystemService.cs
@@ -28,12 +28,13 @@ namespace EasySave.Core.Interfaces
 		/// </summary>
 		/// <param name="sourcePath">The absolute path of the source file.</param>
 		/// <param name="destinationPath">The absolute path of the destination file.</param>
+		/// <param name="progress">Optional. Reports bytes copied for the current file (for progress bar during copy).</param>
 		/// <param name="cancellationToken">Token to cancel the copy operation.</param>
 		/// <returns>
-		/// A <see cref="long"/> representing the time taken in milliseconds. 
+		/// A <see cref="long"/> representing the time taken in milliseconds.
 		/// Returns a negative value if an error occurred.
 		/// </returns>
-		Task<long> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken = default);
+		Task<long> CopyFileAsync(string sourcePath, string destinationPath, IProgress<long>? progress = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Converts a local path to a UNC path (Universal Naming Convention) if necessary.

--- a/src/EasySave.Infrastructure/Backup/BackupExecutor.cs
+++ b/src/EasySave.Infrastructure/Backup/BackupExecutor.cs
@@ -39,7 +39,9 @@ namespace EasySave.Infrastructure.Backup
             _logWriter = logWriter;
         }
 
-        public async Task ExecuteAsync(IReadOnlyList<int> jobIds, CancellationToken cancellationToken = default)
+        private const int ProgressReportThrottleMs = 150;
+
+        public async Task ExecuteAsync(IReadOnlyList<int> jobIds, IProgress<BackupProgress>? progress = null, CancellationToken cancellationToken = default)
         {
             BackupConfiguration? config = await _configRepository.LoadAsync(cancellationToken).ConfigureAwait(false);
             if (config == null || config.Jobs.Count == 0)
@@ -65,9 +67,6 @@ namespace EasySave.Infrastructure.Backup
 
                 int idx = progressList.FindIndex(p => p.BackupName == job.Name);
                 if (idx < 0) continue;
-
-                if (!string.IsNullOrWhiteSpace(job.TargetPath))
-                    _fileSystem.EnsureDirectoryExists(job.TargetPath);
 
                 IBackupStrategy strategy = _strategyFactory.GetStrategy(job.Type);
                 DateTime? differentialSince = job.Type == BackupType.Differential && config.LastFullBackupUtcByJobId.TryGetValue(job.Id, out DateTime since) ? since : null;
@@ -99,13 +98,46 @@ namespace EasySave.Infrastructure.Backup
                     RemainingFilesCount = fileCount,
                     RemainingSizeBytes = totalSize,
                     CurrentSourcePath = null,
-                    CurrentDestinationPath = null
+                    CurrentDestinationPath = null,
+                    EstimatedTimeRemainingSeconds = null
                 };
                 await _stateWriter.WriteStateAsync(progressList, cancellationToken).ConfigureAwait(false);
+                progress?.Report(progressList[idx]);
 
-                // Second pass: stream and copy one file at a time so we never hold the full list.
+                DateTime jobStartUtc = DateTime.UtcNow;
                 long bytesCompleted = 0L;
                 int processedCount = 0;
+                long lastReportTicks = 0;
+
+                void UpdateProgress(long bytesCopiedInCurrentFile, string? uncSource, string? uncDest)
+                {
+                    long totalCompleted = bytesCompleted + bytesCopiedInCurrentFile;
+                    long remainingSize = totalSize - totalCompleted;
+                    double percentDone = totalSize > 0 ? Math.Round((double)totalCompleted / totalSize * 100.0, 2) : 100.0;
+                    double elapsedSeconds = (DateTime.UtcNow - jobStartUtc).TotalSeconds;
+                    double? etaSeconds = null;
+                    if (elapsedSeconds > 0.5 && totalCompleted > 0 && remainingSize > 0)
+                    {
+                        double speedBytesPerSec = totalCompleted / elapsedSeconds;
+                        etaSeconds = remainingSize / speedBytesPerSec;
+                    }
+
+                    progressList[idx] = new BackupProgress
+                    {
+                        BackupName = job.Name,
+                        LastActionTimestamp = DateTime.UtcNow,
+                        State = BackupState.Active,
+                        TotalFilesCount = fileCount,
+                        TotalSizeBytes = totalSize,
+                        ProgressPercent = percentDone,
+                        RemainingFilesCount = fileCount - processedCount,
+                        RemainingSizeBytes = remainingSize,
+                        CurrentSourcePath = uncSource,
+                        CurrentDestinationPath = uncDest,
+                        EstimatedTimeRemainingSeconds = etaSeconds
+                    };
+                }
+
                 IAsyncEnumerable<FileItem> pass2Stream = _fileSystem.EnumerateFilesAsync(job.SourcePath, enumOptions, cancellationToken);
                 await foreach (FileItem item in strategy.GetEligibleFilesAsync(job, pass2Stream, differentialSince, cancellationToken))
                 {
@@ -116,12 +148,26 @@ namespace EasySave.Infrastructure.Backup
                         _fileSystem.EnsureDirectoryExists(dir);
 
                     long fileSize = _fileSystem.GetFileSize(item.FullSourcePath);
-                    long transferMs = await _fileSystem.CopyFileAsync(item.FullSourcePath, destPath, cancellationToken).ConfigureAwait(false);
-
                     string uncSource = _fileSystem.GetUncPath(item.FullSourcePath);
                     string uncDest = _fileSystem.GetUncPath(destPath);
+
+                    var fileProgress = new Progress<long>(bytesCopied =>
+                    {
+                        UpdateProgress(bytesCopied, uncSource, uncDest);
+                        long now = Environment.TickCount64;
+                        if (now - lastReportTicks >= ProgressReportThrottleMs)
+                        {
+                            lastReportTicks = now;
+                            progress?.Report(progressList[idx]);
+                        }
+                    });
+
+                    long transferMs = await _fileSystem.CopyFileAsync(item.FullSourcePath, destPath, fileProgress, cancellationToken).ConfigureAwait(false);
+
+                    string uncSourceLog = _fileSystem.GetUncPath(item.FullSourcePath);
+                    string uncDestLog = _fileSystem.GetUncPath(destPath);
                     TimeSpan transferTime = TimeSpan.FromMilliseconds(Math.Abs(transferMs));
-                    await _logWriter.WriteAsync(new LogEntry(DateTime.UtcNow, job.Name, uncSource, uncDest, fileSize, transferTime), cancellationToken).ConfigureAwait(false);
+                    await _logWriter.WriteAsync(new LogEntry(DateTime.UtcNow, job.Name, uncSourceLog, uncDestLog, fileSize, transferTime), cancellationToken).ConfigureAwait(false);
 
                     bytesCompleted += fileSize;
                     processedCount++;
@@ -140,9 +186,13 @@ namespace EasySave.Infrastructure.Backup
                         RemainingFilesCount = remainingFiles,
                         RemainingSizeBytes = remainingSize,
                         CurrentSourcePath = uncSource,
-                        CurrentDestinationPath = uncDest
+                        CurrentDestinationPath = uncDest,
+                        EstimatedTimeRemainingSeconds = remainingSize > 0 && (DateTime.UtcNow - jobStartUtc).TotalSeconds > 0.5
+                            ? (double?)(remainingSize / (bytesCompleted / (DateTime.UtcNow - jobStartUtc).TotalSeconds))
+                            : null
                     };
                     await _stateWriter.WriteStateAsync(progressList, cancellationToken).ConfigureAwait(false);
+                    progress?.Report(progressList[idx]);
                 }
 
                 progressList[idx] = new BackupProgress
@@ -156,7 +206,8 @@ namespace EasySave.Infrastructure.Backup
                     RemainingFilesCount = 0,
                     RemainingSizeBytes = 0,
                     CurrentSourcePath = null,
-                    CurrentDestinationPath = null
+                    CurrentDestinationPath = null,
+                    EstimatedTimeRemainingSeconds = null
                 };
 
                 if (job.Type == BackupType.Full)

--- a/src/EasySave.Infrastructure/FileSystem/FileSystemService.cs
+++ b/src/EasySave.Infrastructure/FileSystem/FileSystemService.cs
@@ -137,11 +137,16 @@ namespace EasySave.Infrastructure.FileSystem
         }
         
         /// <summary>
-        /// Copy buffer size (80 KB). Trade-off between speed and memory usage to avoid overloading the machine.
+        /// Copy buffer size (1 MB). Trade-off between speed and memory usage to avoid overloading the machine.
         /// </summary>
-        private const int CopyBufferSize = 81920;
+        private const int CopyBufferSize = 1024 * 1024;
 
-        public async Task<long> CopyFileAsync(string sourcePath, string destinationPath, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Report progress at most every this many bytes to limit callback overhead during copy (e.g. 202 MB = ~202 callbacks instead of ~2600).
+        /// </summary>
+        private const long ProgressReportIntervalBytes = CopyBufferSize;
+
+        public async Task<long> CopyFileAsync(string sourcePath, string destinationPath, IProgress<long>? progress = null, CancellationToken cancellationToken = default)
         {
             var stopwatch = Stopwatch.StartNew();
             try
@@ -168,7 +173,22 @@ namespace EasySave.Infrastructure.FileSystem
                 await using (var source = new FileStream(sourcePath, sourceOptions))
                 await using (var dest = new FileStream(destinationPath, destOptions))
                 {
-                    await source.CopyToAsync(dest, CopyBufferSize, cancellationToken).ConfigureAwait(false);
+                    long totalCopied = 0;
+                    long lastReported = -ProgressReportIntervalBytes;
+                    var buffer = new byte[CopyBufferSize];
+                    int read;
+                    while ((read = await source.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false)) > 0)
+                    {
+                        await dest.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                        totalCopied += read;
+                        if (progress != null && totalCopied - lastReported >= ProgressReportIntervalBytes)
+                        {
+                            lastReported = totalCopied;
+                            progress.Report(totalCopied);
+                        }
+                    }
+                    if (progress != null && totalCopied > 0 && lastReported != totalCopied)
+                        progress.Report(totalCopied);
                 }
 
                 stopwatch.Stop();

--- a/src/EasySave.Infrastructure/Persistence/JsonStateWriter.cs
+++ b/src/EasySave.Infrastructure/Persistence/JsonStateWriter.cs
@@ -60,7 +60,8 @@ namespace EasySave.Infrastructure.Persistence
                     RemainingFilesCount = p.RemainingFilesCount,
                     RemainingSizeBytes = p.RemainingSizeBytes,
                     CurrentSourcePath = p.CurrentSourcePath,
-                    CurrentDestinationPath = p.CurrentDestinationPath
+                    CurrentDestinationPath = p.CurrentDestinationPath,
+                    EstimatedTimeRemainingSeconds = p.EstimatedTimeRemainingSeconds
                 }).ToList()
             };
             string json = JsonSerializer.Serialize(dto, _jsonOptions) + Environment.NewLine;
@@ -85,6 +86,7 @@ namespace EasySave.Infrastructure.Persistence
             public long RemainingSizeBytes { get; set; }
             public string? CurrentSourcePath { get; set; }
             public string? CurrentDestinationPath { get; set; }
+            public double? EstimatedTimeRemainingSeconds { get; set; }
         }
     }
 }

--- a/tests/EasySave.Console.Tests/TuiRunnerTests.cs
+++ b/tests/EasySave.Console.Tests/TuiRunnerTests.cs
@@ -288,7 +288,7 @@ public sealed class TuiRunnerTests : IDisposable
     {
         public List<IReadOnlyList<int>> Executions { get; } = new();
 
-        public Task ExecuteAsync(IReadOnlyList<int> jobIds, CancellationToken cancellationToken = default)
+        public Task ExecuteAsync(IReadOnlyList<int> jobIds, IProgress<BackupProgress>? progress = null, CancellationToken cancellationToken = default)
         {
             Executions.Add(new List<int>(jobIds));
             return Task.CompletedTask;

--- a/tests/EasySave.Infrastructure.Tests/BackupExecutorTests.cs
+++ b/tests/EasySave.Infrastructure.Tests/BackupExecutorTests.cs
@@ -186,7 +186,7 @@ public sealed class BackupExecutorTests : IDisposable
         CancellationTokenSource cts = new();
         cts.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => executor.ExecuteAsync(new[] { 1 }, cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(() => executor.ExecuteAsync(new[] { 1 }, null, cts.Token));
     }
 
     [Fact]

--- a/tests/EasySave.Infrastructure.Tests/FileSystemServiceTests.cs
+++ b/tests/EasySave.Infrastructure.Tests/FileSystemServiceTests.cs
@@ -101,7 +101,7 @@ public sealed class FileSystemServiceTests : IDisposable
 
         var destinationPath = Path.Combine(_tempRoot, "dest", "nested", "file.txt");
 
-        var duration = await ((IFileSystemService)_service).CopyFileAsync(sourcePath, destinationPath, CancellationToken.None);
+        var duration = await ((IFileSystemService)_service).CopyFileAsync(sourcePath, destinationPath, null, CancellationToken.None);
 
         Assert.True(duration >= 0, "Successful copy should return a non-negative duration.");
         Assert.True(File.Exists(destinationPath), "Destination file should exist after copy.");
@@ -115,7 +115,7 @@ public sealed class FileSystemServiceTests : IDisposable
         var missingSource = Path.Combine(_tempRoot, "unknown", "missing.txt");
         var destinationPath = Path.Combine(_tempRoot, "dest", "file.txt");
 
-        var duration = await ((IFileSystemService)_service).CopyFileAsync(missingSource, destinationPath, CancellationToken.None);
+        var duration = await ((IFileSystemService)_service).CopyFileAsync(missingSource, destinationPath, null, CancellationToken.None);
 
         Assert.True(duration <= 0, "Failure should yield a non-positive duration.");
         Assert.False(File.Exists(destinationPath), "Destination file should not exist when copy fails.");


### PR DESCRIPTION
## Description

Ajout d'une barre de progresion en fonction du nombre de MB déplacé sur le total et d'une estimation du temps restant.

## Liens vers les issues

- Closes #125 

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [x] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
