### PR TITLE
feat(gui): add Avalonia GUI with main window, tabs and i18n

### DIFF
--- a/EasySave.sln
+++ b/EasySave.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.2.11415.280 d18.0
+VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyLog", "src\EasyLog\EasyLog.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
@@ -18,6 +18,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Console", "src\EasySave.Console\EasySave.Console.csproj", "{3A7A6424-DA92-47A4-9EC4-2CDD8B7C08AD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Console.Tests", "tests\EasySave.Console.Tests\EasySave.Console.Tests.csproj", "{483C8D20-E8DD-4FD5-95A7-EE24C976D020}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasySave.Gui", "src\EasySave.Gui\EasySave.Gui.csproj", "{C5214A7E-7C1D-4873-8EF5-900658404F90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -113,6 +117,18 @@ Global
 		{483C8D20-E8DD-4FD5-95A7-EE24C976D020}.Release|x64.Build.0 = Release|Any CPU
 		{483C8D20-E8DD-4FD5-95A7-EE24C976D020}.Release|x86.ActiveCfg = Release|Any CPU
 		{483C8D20-E8DD-4FD5-95A7-EE24C976D020}.Release|x86.Build.0 = Release|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Debug|x64.Build.0 = Debug|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Debug|x86.Build.0 = Debug|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Release|x64.ActiveCfg = Release|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Release|x64.Build.0 = Release|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Release|x86.ActiveCfg = Release|Any CPU
+		{C5214A7E-7C1D-4873-8EF5-900658404F90}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -121,6 +137,7 @@ Global
 		{0E94B023-C02C-4AD3-8723-55305E094D66} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{1A2B3C4D-5E6F-7890-ABCD-EF1234567891} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{483C8D20-E8DD-4FD5-95A7-EE24C976D020} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{C5214A7E-7C1D-4873-8EF5-900658404F90} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E5F6A7B8-C9D0-1234-EF01-345678901234}

--- a/src/EasySave.Gui/App.axaml
+++ b/src/EasySave.Gui/App.axaml
@@ -1,0 +1,10 @@
+<Application
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:sty="using:FluentAvalonia.Styling"
+    x:Class="EasySave.Gui.App"
+    RequestedThemeVariant="Light">
+  <Application.Styles>
+    <sty:FluentAvaloniaTheme />
+  </Application.Styles>
+</Application>

--- a/src/EasySave.Gui/App.axaml.cs
+++ b/src/EasySave.Gui/App.axaml.cs
@@ -1,0 +1,46 @@
+using System;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using EasySave.Gui.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasySave.Gui;
+
+/// <summary>
+/// Avalonia application class for the EasySave GUI.
+/// Responsible for loading XAML resources and wiring the main window.
+/// </summary>
+public partial class App : Application
+{
+    /// <summary>
+    /// Global service provider used by the GUI to resolve services and ViewModels.
+    /// Set once in <see cref="Program.Main"/>.
+    /// </summary>
+    public static IServiceProvider? ServiceProvider { get; set; }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    /// <inheritdoc />
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && ServiceProvider != null)
+        {
+            var mainVm = ServiceProvider.GetRequiredService<ViewModels.MainWindowViewModel>();
+            desktop.MainWindow = new MainWindow { DataContext = mainVm };
+
+            var folderPicker = ServiceProvider.GetRequiredService<IFolderPickerService>();
+            folderPicker.SetOwner(desktop.MainWindow);
+
+            var configHolder = ServiceProvider.GetRequiredService<IConfigurationHolder>();
+            // Trigger initial configuration load without blocking the UI thread.
+            _ = configHolder.ReloadAsync();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/src/EasySave.Gui/CompositionRoot.cs
+++ b/src/EasySave.Gui/CompositionRoot.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using EasyLog;
+using EasySave.Core.Interfaces;
+using EasySave.Gui.Services;
+using EasySave.Gui.ViewModels;
+using EasySave.Infrastructure.Backup;
+using EasySave.Infrastructure.FileSystem;
+using EasySave.Infrastructure.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EasySave.Gui;
+
+/// <summary>
+/// Central composition root for the GUI application.
+/// Registers infrastructure services and ViewModels in the dependency injection container.
+/// </summary>
+public static class CompositionRoot
+{
+    /// <summary>
+    /// Builds and configures the <see cref="IServiceProvider"/> for the GUI layer.
+    /// </summary>
+    /// <param name="basePath">
+    /// Base directory that will be used by infrastructure services to locate configuration,
+    /// state and log files.
+    /// </param>
+    /// <returns>The fully configured service provider.</returns>
+    public static IServiceProvider Build(string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(basePath))
+            throw new ArgumentNullException(nameof(basePath));
+
+        string normalizedBasePath = Path.GetFullPath(basePath);
+        var services = new ServiceCollection();
+
+        // Paths and persistence
+        services.AddSingleton(new EasySavePaths(normalizedBasePath));
+        services.AddSingleton<IConfigurationRepository>(sp =>
+            new JsonConfigurationRepository(sp.GetRequiredService<EasySavePaths>().BaseDirectory));
+        services.AddSingleton<IFileSystemService>(_ => new FileSystemService());
+        services.AddSingleton<IStateWriter>(sp =>
+        {
+            var paths = sp.GetRequiredService<EasySavePaths>();
+            return new JsonStateWriter(paths.StateFilePath);
+        });
+
+        // Logging
+        services.AddSingleton<DailyLogWriter>(sp => new DailyLogWriter(sp.GetRequiredService<EasySavePaths>().LogDirectory));
+        services.AddSingleton<XmlDailyLogWriter>(sp => new XmlDailyLogWriter(sp.GetRequiredService<EasySavePaths>().LogDirectory));
+        services.AddSingleton<ILogWriter>(sp =>
+        {
+            var configRepo = sp.GetRequiredService<IConfigurationRepository>();
+            var jsonWriter = sp.GetRequiredService<DailyLogWriter>();
+            var xmlWriter = sp.GetRequiredService<XmlDailyLogWriter>();
+            return new ConfigurableLogWriter(configRepo, jsonWriter, xmlWriter);
+        });
+
+        // Backup execution
+        services.AddSingleton<IBackupStrategyFactory>(_ => new BackupStrategyFactory());
+        services.AddSingleton<IBackupExecutor>(sp => new BackupExecutor(
+            sp.GetRequiredService<IConfigurationRepository>(),
+            sp.GetRequiredService<IBackupStrategyFactory>(),
+            sp.GetRequiredService<IFileSystemService>(),
+            sp.GetRequiredService<IStateWriter>(),
+            sp.GetRequiredService<ILogWriter>()));
+
+        // GUI services (abstractions for SOLID)
+        services.AddSingleton<ILocalizationProvider, LocalizationProvider>();
+        services.AddSingleton<IConfigurationHolder, ConfigurationHolder>();
+        services.AddSingleton<IFolderPickerService, FolderPickerService>();
+
+        // ViewModels (one per screen / tab)
+        services.AddTransient<JobsTabViewModel>();
+        services.AddTransient<CreateEditJobViewModel>();
+        services.AddTransient<SettingsViewModel>();
+        services.AddTransient<MainWindowViewModel>();
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/EasySave.Gui/EasySave.Gui.csproj
+++ b/src/EasySave.Gui/EasySave.Gui.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.11" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
+    <PackageReference Include="FluentAvaloniaUI" Version="2.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EasySave.Core\EasySave.Core.csproj" />
+    <ProjectReference Include="..\EasySave.Infrastructure\EasySave.Infrastructure.csproj" />
+    <ProjectReference Include="..\EasyLog\EasyLog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/EasySave.Gui/EasySavePaths.cs
+++ b/src/EasySave.Gui/EasySavePaths.cs
@@ -1,0 +1,44 @@
+using System.IO;
+
+namespace EasySave.Gui;
+
+/// <summary>
+/// Provides strongly-typed paths used by the EasySave GUI
+/// for configuration, state and log files.
+/// </summary>
+public sealed class EasySavePaths
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EasySavePaths"/> class.
+    /// </summary>
+    /// <param name="baseDirectory">
+    /// Base directory where configuration, state file and log files are stored.
+    /// </param>
+    public EasySavePaths(string baseDirectory)
+    {
+        BaseDirectory = Path.GetFullPath(baseDirectory ?? string.Empty);
+        ConfigFilePath = Path.Combine(BaseDirectory, "backup-config.json");
+        StateFilePath = Path.Combine(BaseDirectory, "state.json");
+        LogDirectory = BaseDirectory;
+    }
+
+    /// <summary>
+    /// Directory containing configuration, state and log files.
+    /// </summary>
+    public string BaseDirectory { get; }
+
+    /// <summary>
+    /// Full path to <c>backup-config.json</c>.
+    /// </summary>
+    public string ConfigFilePath { get; }
+
+    /// <summary>
+    /// Full path to <c>state.json</c>.
+    /// </summary>
+    public string StateFilePath { get; }
+
+    /// <summary>
+    /// Directory where daily log files are stored.
+    /// </summary>
+    public string LogDirectory { get; }
+}

--- a/src/EasySave.Gui/MainWindow.axaml
+++ b/src/EasySave.Gui/MainWindow.axaml
@@ -1,0 +1,161 @@
+<Window
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Class="EasySave.Gui.MainWindow"
+    Title="{Binding WindowTitle}"
+    Width="1024"
+    Height="700"
+    MinWidth="860"
+    MinHeight="580"
+    Background="#FAFAFA">
+  <Window.Styles>
+    <Style Selector="Window">
+      <Setter Property="Background" Value="#FAFAFA" />
+    </Style>
+    <Style Selector="TabControl">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="TabItem">
+      <Setter Property="Padding" Value="16,10" />
+      <Setter Property="FontSize" Value="14" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="TabItem:selected">
+      <Setter Property="Foreground" Value="#0067C0" />
+    </Style>
+    <Style Selector="Border.card">
+      <Setter Property="Background" Value="White" />
+      <Setter Property="BorderBrush" Value="#E5E7EB" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="8" />
+      <Setter Property="Padding" Value="20" />
+    </Style>
+    <Style Selector="Button.primary">
+      <Setter Property="Background" Value="#0067C0" />
+      <Setter Property="Foreground" Value="White" />
+      <Setter Property="CornerRadius" Value="6" />
+      <Setter Property="Padding" Value="16,10" />
+    </Style>
+    <Style Selector="Button.primary:pointerover">
+      <Setter Property="Background" Value="#005A9E" />
+    </Style>
+    <Style Selector="Button.primary:pressed">
+      <Setter Property="Background" Value="#004578" />
+    </Style>
+  </Window.Styles>
+
+  <Grid RowDefinitions="Auto,*" Margin="0">
+    <!-- En-tête blanc moderne -->
+    <Border Grid.Row="0" Background="White" BorderBrush="#E5E7EB" BorderThickness="0,0,0,1" Padding="24,20">
+      <Grid ColumnDefinitions="Auto,*" ColumnSpacing="16">
+        <Border Width="48" Height="48" CornerRadius="10" Background="#0067C0" VerticalAlignment="Center">
+          <TextBlock Text="ES" FontSize="18" FontWeight="Bold" Foreground="White"
+                     HorizontalAlignment="Center" VerticalAlignment="Center" />
+        </Border>
+        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="2">
+          <TextBlock Text="{Binding HeaderTitle}" FontSize="22" FontWeight="Bold" Foreground="#111827" />
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <TabControl Grid.Row="1" Margin="24,20">
+      <TabItem Header="{Binding TabJobs}">
+        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="16" Margin="0,8,0,0">
+          <StackPanel Orientation="Horizontal" Spacing="12">
+            <Button Content="{Binding JobsTab.RefreshButtonText}" Command="{Binding JobsTab.Refresh}"
+                    IsEnabled="{Binding JobsTab.CanRefresh}" Classes="primary" />
+            <Button Content="{Binding JobsTab.RunSelectedButtonText}" Command="{Binding JobsTab.RunSelected}"
+                    CommandParameter="{Binding JobsTab.SelectedJob}"
+                    IsEnabled="{Binding JobsTab.CanRunSelected}" />
+          </StackPanel>
+          <Grid Row="1" ColumnDefinitions="*,*" ColumnSpacing="16">
+            <Border Grid.Column="0" Classes="card">
+              <StackPanel Spacing="12">
+                <TextBlock Text="{Binding JobsTab.JobsListTitle}" FontWeight="SemiBold" FontSize="14" Foreground="#374151" />
+                <ListBox ItemsSource="{Binding JobsTab.Jobs}"
+                         SelectedItem="{Binding JobsTab.SelectedJob}"
+                         MinHeight="240" Background="Transparent" BorderThickness="0" />
+              </StackPanel>
+            </Border>
+            <Border Grid.Column="1" Classes="card">
+              <StackPanel Spacing="12">
+                <TextBlock Text="{Binding JobsTab.DetailsTitle}" FontWeight="SemiBold" FontSize="14" Foreground="#374151" />
+                <TextBlock Text="{Binding JobsTab.JobDetailsText}" TextWrapping="Wrap" Foreground="#4B5563" LineHeight="22" />
+              </StackPanel>
+            </Border>
+          </Grid>
+          <TextBlock Grid.Row="2" Text="{Binding JobsTab.JobsHintText}" FontSize="12" Foreground="#9CA3AF" />
+          <TextBlock Grid.Row="3" Text="{Binding JobsTab.StatusText}" TextWrapping="Wrap" Foreground="#0067C0" FontSize="13" />
+        </Grid>
+      </TabItem>
+
+      <TabItem Header="{Binding TabCreateEdit}">
+        <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="16" Margin="0,8,0,0">
+          <Border Classes="card" Padding="16">
+            <StackPanel Orientation="Horizontal" Spacing="12">
+              <TextBlock Text="{Binding CreateEditTab.ExistingJobLabel}" VerticalAlignment="Center" Foreground="#374151" />
+              <ComboBox ItemsSource="{Binding CreateEditTab.ExistingJobs}"
+                        SelectedItem="{Binding CreateEditTab.SelectedExistingJob}"
+                        Width="260" />
+              <Button Content="{Binding CreateEditTab.NewJobButtonText}" Command="{Binding CreateEditTab.NewJob}" />
+            </StackPanel>
+          </Border>
+          <TextBlock Grid.Row="1" Text="{Binding CreateEditTab.EditHintText}" FontSize="12" Foreground="#9CA3AF" />
+          <Border Grid.Row="2" Classes="card">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="16" RowSpacing="14">
+              <TextBlock Text="{Binding CreateEditTab.LabelName}" VerticalAlignment="Center" Foreground="#374151" />
+              <TextBox Grid.Column="1" Text="{Binding CreateEditTab.Name}" Watermark="My backup" />
+              <TextBlock Grid.Row="1" Text="{Binding CreateEditTab.LabelSource}" VerticalAlignment="Center" Foreground="#374151" />
+              <Grid Grid.Row="1" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding CreateEditTab.SourcePath}" Watermark="C:\Source" />
+                <Button Grid.Column="1" Content="{Binding CreateEditTab.BrowseButtonText}" Command="{Binding CreateEditTab.PickSourceFolder}" MinWidth="90" />
+              </Grid>
+              <TextBlock Grid.Row="2" Text="{Binding CreateEditTab.LabelTarget}" VerticalAlignment="Center" Foreground="#374151" />
+              <Grid Grid.Row="2" Grid.Column="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <TextBox Text="{Binding CreateEditTab.TargetPath}" Watermark="D:\Backup" />
+                <Button Grid.Column="1" Content="{Binding CreateEditTab.BrowseButtonText}" Command="{Binding CreateEditTab.PickTargetFolder}" MinWidth="90" />
+              </Grid>
+              <TextBlock Grid.Row="3" Text="{Binding CreateEditTab.LabelType}" VerticalAlignment="Center" Foreground="#374151" />
+              <ComboBox Grid.Row="3" Grid.Column="1" SelectedIndex="{Binding CreateEditTab.SelectedTypeIndex}" HorizontalAlignment="Left" MinWidth="180">
+                <ComboBoxItem Content="{Binding CreateEditTab.FullBackupLabel}" />
+                <ComboBoxItem Content="{Binding CreateEditTab.DifferentialBackupLabel}" />
+              </ComboBox>
+              <TextBlock Grid.Row="4" Text="{Binding CreateEditTab.LabelExcludeExtensions}" VerticalAlignment="Center" Foreground="#374151" />
+              <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding CreateEditTab.ExcludeExtensions}" Watermark=".tmp,.log" />
+              <TextBlock Grid.Row="5" Text="{Binding CreateEditTab.LabelExcludeDirs}" VerticalAlignment="Center" Foreground="#374151" />
+              <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding CreateEditTab.ExcludeDirectories}" Watermark="node_modules,.git" />
+            </Grid>
+          </Border>
+          <StackPanel Grid.Row="3" Spacing="10">
+            <Button Content="{Binding CreateEditTab.SaveButtonText}" Command="{Binding CreateEditTab.SaveJob}" Classes="primary" HorizontalAlignment="Left" />
+            <TextBlock Text="{Binding CreateEditTab.StatusText}" TextWrapping="Wrap" Foreground="#0067C0" FontSize="13" />
+          </StackPanel>
+        </Grid>
+      </TabItem>
+
+      <TabItem Header="{Binding TabSettings}">
+        <Border Classes="card" Margin="0,8,0,0" MaxWidth="700" HorizontalAlignment="Left">
+          <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="160,*" RowSpacing="14" ColumnSpacing="16">
+            <TextBlock Text="{Binding SettingsTab.LabelBasePath}" VerticalAlignment="Center" Foreground="#374151" />
+            <TextBlock Grid.Column="1" Text="{Binding SettingsTab.BasePath}" TextWrapping="Wrap" Foreground="#4B5563" />
+            <TextBlock Grid.Row="1" Text="{Binding SettingsTab.LabelConfigPath}" VerticalAlignment="Center" Foreground="#374151" />
+            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding SettingsTab.ConfigPath}" TextWrapping="Wrap" Foreground="#4B5563" />
+            <TextBlock Grid.Row="2" Text="{Binding SettingsTab.LabelStatePath}" VerticalAlignment="Center" Foreground="#374151" />
+            <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding SettingsTab.StatePath}" TextWrapping="Wrap" Foreground="#4B5563" />
+            <TextBlock Grid.Row="3" Text="{Binding SettingsTab.LabelLogDir}" VerticalAlignment="Center" Foreground="#374151" />
+            <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding SettingsTab.LogDirectory}" TextWrapping="Wrap" Foreground="#4B5563" />
+            <TextBlock Grid.Row="4" Text="{Binding SettingsTab.LabelLogFormat}" VerticalAlignment="Center" Foreground="#374151" />
+            <ComboBox Grid.Row="4" Grid.Column="1" SelectedIndex="{Binding SettingsTab.LogFormatIndex}" Width="160" HorizontalAlignment="Left">
+              <ComboBoxItem Content="Json" />
+              <ComboBoxItem Content="Xml" />
+            </ComboBox>
+            <Button Grid.Row="5" Grid.Column="1" Content="{Binding SettingsTab.SaveSettingsButtonText}"
+                    Command="{Binding SettingsTab.SaveSettings}" Classes="primary" HorizontalAlignment="Left" />
+            <TextBlock Grid.Row="6" Grid.ColumnSpan="2" Text="{Binding SettingsTab.StatusText}" TextWrapping="Wrap" Foreground="#0067C0" FontSize="13" />
+          </Grid>
+        </Border>
+      </TabItem>
+    </TabControl>
+  </Grid>
+</Window>

--- a/src/EasySave.Gui/MainWindow.axaml.cs
+++ b/src/EasySave.Gui/MainWindow.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls;
+
+namespace EasySave.Gui;
+
+/// <summary>
+/// Main window view: contains only generated XAML content,
+/// the DataContext is provided by <see cref="App"/> (pure MVVM).
+/// </summary>
+public partial class MainWindow : Window
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainWindow"/> class.
+    /// </summary>
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/EasySave.Gui/Program.cs
+++ b/src/EasySave.Gui/Program.cs
@@ -1,0 +1,37 @@
+using System;
+using Avalonia;
+
+namespace EasySave.Gui;
+
+/// <summary>
+/// Application entry point for the EasySave GUI.
+/// Responsible for building the DI container and bootstrapping Avalonia.
+/// </summary>
+internal sealed class Program
+{
+    [STAThread]
+    /// <summary>
+    /// Main entry method for the GUI process.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    public static void Main(string[] args)
+    {
+        string? envBasePath = Environment.GetEnvironmentVariable("EASYSAVE_BASE_PATH");
+        string basePath = !string.IsNullOrWhiteSpace(envBasePath) ? envBasePath : AppContext.BaseDirectory;
+        App.ServiceProvider = CompositionRoot.Build(basePath);
+
+        BuildAvaloniaApp()
+            .StartWithClassicDesktopLifetime(args);
+    }
+
+    /// <summary>
+    /// Configures the Avalonia <see cref="AppBuilder"/> for the GUI.
+    /// </summary>
+    /// <returns>The configured <see cref="AppBuilder"/> instance.</returns>
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        return AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+    }
+}

--- a/src/EasySave.Gui/Resources/Strings.fr.resx
+++ b/src/EasySave.Gui/Resources/Strings.fr.resx
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Gui_WindowTitle" xml:space="preserve">
+    <value>EasySave</value>
+  </data>
+  <data name="Gui_HeaderTitle" xml:space="preserve">
+    <value>EasySave</value>
+  </data>
+  <data name="Gui_TabJobs" xml:space="preserve">
+    <value>Travaux</value>
+  </data>
+  <data name="Gui_TabCreateEdit" xml:space="preserve">
+    <value>Créer / Modifier</value>
+  </data>
+  <data name="Gui_TabSettings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="Gui_JobsListTitle" xml:space="preserve">
+    <value>Liste des travaux</value>
+  </data>
+  <data name="Gui_DetailsTitle" xml:space="preserve">
+    <value>Détails</value>
+  </data>
+  <data name="Gui_Refresh" xml:space="preserve">
+    <value>Rafraîchir</value>
+  </data>
+  <data name="Gui_RunSelected" xml:space="preserve">
+    <value>Lancer le travail sélectionné</value>
+  </data>
+  <data name="Gui_JobsRefreshed" xml:space="preserve">
+    <value>Travaux rechargés depuis la configuration.</value>
+  </data>
+  <data name="Gui_SelectJobFirst" xml:space="preserve">
+    <value>Veuillez sélectionner un travail.</value>
+  </data>
+  <data name="Gui_JobRunning" xml:space="preserve">
+    <value>Exécution du travail #{0}...</value>
+  </data>
+  <data name="Gui_JobSuccess" xml:space="preserve">
+    <value>Travail #{0} terminé avec succès.</value>
+  </data>
+  <data name="Gui_JobError" xml:space="preserve">
+    <value>Erreur : {0}</value>
+  </data>
+  <data name="Gui_JobDetailsFormat" xml:space="preserve">
+    <value>ID : {0}&#x0a;Nom : {1}&#x0a;Type : {2}&#x0a;Source : {3}&#x0a;Cible : {4}&#x0a;Extensions exclues : {5}&#x0a;Dossiers exclus : {6}</value>
+  </data>
+  <data name="Gui_JobsHint" xml:space="preserve">
+    <value>Cliquez sur un travail pour afficher ses informations.</value>
+  </data>
+  <data name="Gui_ExistingJob" xml:space="preserve">
+    <value>Travail existant :</value>
+  </data>
+  <data name="Gui_NewJob" xml:space="preserve">
+    <value>Nouveau travail</value>
+  </data>
+  <data name="Gui_EditHint" xml:space="preserve">
+    <value>Laisser vide pour conserver la valeur actuelle lors de la modification.</value>
+  </data>
+  <data name="Gui_LabelName" xml:space="preserve">
+    <value>Nom :</value>
+  </data>
+  <data name="Gui_LabelSource" xml:space="preserve">
+    <value>Dossier source :</value>
+  </data>
+  <data name="Gui_Browse" xml:space="preserve">
+    <value>Parcourir...</value>
+  </data>
+  <data name="Gui_PickSourceFolder" xml:space="preserve">
+    <value>Choisir le dossier source</value>
+  </data>
+  <data name="Gui_PickTargetFolder" xml:space="preserve">
+    <value>Choisir le dossier cible</value>
+  </data>
+  <data name="Gui_LabelTarget" xml:space="preserve">
+    <value>Dossier cible :</value>
+  </data>
+  <data name="Gui_LabelType" xml:space="preserve">
+    <value>Type :</value>
+  </data>
+  <data name="Gui_LabelExcludeExtensions" xml:space="preserve">
+    <value>Extensions exclues :</value>
+  </data>
+  <data name="Gui_LabelExcludeDirs" xml:space="preserve">
+    <value>Dossiers exclus :</value>
+  </data>
+  <data name="Gui_Save" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="Gui_EditModeCreate" xml:space="preserve">
+    <value>Mode création : saisissez les informations puis cliquez sur Enregistrer.</value>
+  </data>
+  <data name="Gui_EditModeEdit" xml:space="preserve">
+    <value>Édition du travail #{0}.</value>
+  </data>
+  <data name="Gui_RequiredFields" xml:space="preserve">
+    <value>Nom, source et cible sont obligatoires.</value>
+  </data>
+  <data name="Gui_MaxJobsDeleteOne" xml:space="preserve">
+    <value>Nombre max de travaux atteint. Supprimez-en un pour en ajouter.</value>
+  </data>
+  <data name="Gui_LabelBasePath" xml:space="preserve">
+    <value>Chemin de base :</value>
+  </data>
+  <data name="Gui_LabelConfigPath" xml:space="preserve">
+    <value>Fichier config :</value>
+  </data>
+  <data name="Gui_LabelStatePath" xml:space="preserve">
+    <value>Fichier d'état :</value>
+  </data>
+  <data name="Gui_LabelLogDir" xml:space="preserve">
+    <value>Dossier des logs :</value>
+  </data>
+  <data name="Gui_LabelLogFormat" xml:space="preserve">
+    <value>Format des logs :</value>
+  </data>
+  <data name="Gui_SaveSettings" xml:space="preserve">
+    <value>Enregistrer les paramètres</value>
+  </data>
+  <data name="Gui_SettingsSaved" xml:space="preserve">
+    <value>Paramètres enregistrés. Format actif : {0}.</value>
+  </data>
+  <data name="FullBackup" xml:space="preserve">
+    <value>Sauvegarde complète</value>
+  </data>
+  <data name="DifferentialBackup" xml:space="preserve">
+    <value>Sauvegarde différentielle</value>
+  </data>
+  <data name="NoJobsFound" xml:space="preserve">
+    <value>Aucun travail de sauvegarde trouvé.</value>
+  </data>
+  <data name="MaxJobsReached" xml:space="preserve">
+    <value>Nombre maximum de travaux (5) atteint.</value>
+  </data>
+  <data name="JobCreated" xml:space="preserve">
+    <value>Travail {0} créé avec succès.</value>
+  </data>
+  <data name="TuiJobUpdated" xml:space="preserve">
+    <value>Le travail {0} a été mis à jour.</value>
+  </data>
+</root>

--- a/src/EasySave.Gui/Resources/Strings.resx
+++ b/src/EasySave.Gui/Resources/Strings.resx
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>1.3</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Gui_WindowTitle" xml:space="preserve">
+    <value>EasySave</value>
+  </data>
+  <data name="Gui_HeaderTitle" xml:space="preserve">
+    <value>EasySave</value>
+  </data>
+  <data name="Gui_TabJobs" xml:space="preserve">
+    <value>Jobs</value>
+  </data>
+  <data name="Gui_TabCreateEdit" xml:space="preserve">
+    <value>Create / Edit</value>
+  </data>
+  <data name="Gui_TabSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Gui_JobsListTitle" xml:space="preserve">
+    <value>Job list</value>
+  </data>
+  <data name="Gui_DetailsTitle" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="Gui_Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="Gui_RunSelected" xml:space="preserve">
+    <value>Run selected job</value>
+  </data>
+  <data name="Gui_JobsRefreshed" xml:space="preserve">
+    <value>Jobs reloaded from configuration.</value>
+  </data>
+  <data name="Gui_SelectJobFirst" xml:space="preserve">
+    <value>Please select a job first.</value>
+  </data>
+  <data name="Gui_JobRunning" xml:space="preserve">
+    <value>Running job #{0}...</value>
+  </data>
+  <data name="Gui_JobSuccess" xml:space="preserve">
+    <value>Job #{0} completed successfully.</value>
+  </data>
+  <data name="Gui_JobError" xml:space="preserve">
+    <value>Error: {0}</value>
+  </data>
+  <data name="Gui_JobDetailsFormat" xml:space="preserve">
+    <value>ID: {0}&#x0a;Name: {1}&#x0a;Type: {2}&#x0a;Source: {3}&#x0a;Target: {4}&#x0a;Excluded extensions: {5}&#x0a;Excluded directories: {6}</value>
+  </data>
+  <data name="Gui_JobsHint" xml:space="preserve">
+    <value>Click a job to view its details.</value>
+  </data>
+  <data name="Gui_ExistingJob" xml:space="preserve">
+    <value>Existing job:</value>
+  </data>
+  <data name="Gui_NewJob" xml:space="preserve">
+    <value>New job</value>
+  </data>
+  <data name="Gui_EditHint" xml:space="preserve">
+    <value>Leave a field empty to keep the current value when editing.</value>
+  </data>
+  <data name="Gui_LabelName" xml:space="preserve">
+    <value>Name:</value>
+  </data>
+  <data name="Gui_LabelSource" xml:space="preserve">
+    <value>Source folder:</value>
+  </data>
+  <data name="Gui_Browse" xml:space="preserve">
+    <value>Browse...</value>
+  </data>
+  <data name="Gui_PickSourceFolder" xml:space="preserve">
+    <value>Select source folder</value>
+  </data>
+  <data name="Gui_PickTargetFolder" xml:space="preserve">
+    <value>Select target folder</value>
+  </data>
+  <data name="Gui_LabelTarget" xml:space="preserve">
+    <value>Target folder:</value>
+  </data>
+  <data name="Gui_LabelType" xml:space="preserve">
+    <value>Type:</value>
+  </data>
+  <data name="Gui_LabelExcludeExtensions" xml:space="preserve">
+    <value>Excluded extensions:</value>
+  </data>
+  <data name="Gui_LabelExcludeDirs" xml:space="preserve">
+    <value>Excluded directories:</value>
+  </data>
+  <data name="Gui_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Gui_EditModeCreate" xml:space="preserve">
+    <value>Create mode: enter details and click Save.</value>
+  </data>
+  <data name="Gui_EditModeEdit" xml:space="preserve">
+    <value>Editing job #{0}.</value>
+  </data>
+  <data name="Gui_RequiredFields" xml:space="preserve">
+    <value>Name, source and target are required.</value>
+  </data>
+  <data name="Gui_MaxJobsDeleteOne" xml:space="preserve">
+    <value>Maximum jobs reached. Delete one to add a new job.</value>
+  </data>
+  <data name="Gui_LabelBasePath" xml:space="preserve">
+    <value>Base path:</value>
+  </data>
+  <data name="Gui_LabelConfigPath" xml:space="preserve">
+    <value>Config file:</value>
+  </data>
+  <data name="Gui_LabelStatePath" xml:space="preserve">
+    <value>State file:</value>
+  </data>
+  <data name="Gui_LabelLogDir" xml:space="preserve">
+    <value>Log directory:</value>
+  </data>
+  <data name="Gui_LabelLogFormat" xml:space="preserve">
+    <value>Log format:</value>
+  </data>
+  <data name="Gui_SaveSettings" xml:space="preserve">
+    <value>Save settings</value>
+  </data>
+  <data name="Gui_SettingsSaved" xml:space="preserve">
+    <value>Settings saved. Active format: {0}.</value>
+  </data>
+  <data name="FullBackup" xml:space="preserve">
+    <value>Full backup</value>
+  </data>
+  <data name="DifferentialBackup" xml:space="preserve">
+    <value>Differential backup</value>
+  </data>
+  <data name="NoJobsFound" xml:space="preserve">
+    <value>No backup jobs found.</value>
+  </data>
+  <data name="MaxJobsReached" xml:space="preserve">
+    <value>Maximum number of jobs (5) reached.</value>
+  </data>
+  <data name="JobCreated" xml:space="preserve">
+    <value>Job {0} created successfully.</value>
+  </data>
+  <data name="TuiJobUpdated" xml:space="preserve">
+    <value>Job {0} has been updated.</value>
+  </data>
+</root>

--- a/src/EasySave.Gui/Services/ConfigurationHolder.cs
+++ b/src/EasySave.Gui/Services/ConfigurationHolder.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using EasySave.Core.Entities;
+using EasySave.Core.Enums;
+using EasySave.Core.Interfaces;
+
+namespace EasySave.Gui.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IConfigurationHolder"/>, keeping the
+/// current configuration in memory and delegating persistence to <see cref="IConfigurationRepository"/>.
+/// </summary>
+public sealed class ConfigurationHolder : IConfigurationHolder
+{
+    private readonly IConfigurationRepository _repository;
+    private readonly string _baseDirectory;
+    private BackupConfiguration _current;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationHolder"/> class.
+    /// </summary>
+    /// <param name="repository">Repository used to load and save configuration.</param>
+    /// <param name="paths">Helper containing the base directory for configuration files.</param>
+    public ConfigurationHolder(IConfigurationRepository repository, EasySavePaths paths)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _baseDirectory = paths?.BaseDirectory ?? throw new ArgumentNullException(nameof(paths));
+        _current = BuildDefault(_baseDirectory);
+    }
+
+    /// <inheritdoc />
+    public BackupConfiguration Current => _current;
+
+    /// <inheritdoc />
+    public event EventHandler? ConfigurationChanged;
+
+    /// <inheritdoc />
+    public async Task ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        var loaded = await _repository.LoadAsync(cancellationToken).ConfigureAwait(false);
+        _current = loaded ?? BuildDefault(_baseDirectory);
+        ConfigurationChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(BackupConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        await _repository.SaveAsync(configuration, cancellationToken).ConfigureAwait(false);
+        _current = configuration;
+        ConfigurationChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static BackupConfiguration BuildDefault(string baseDirectory)
+    {
+        return new BackupConfiguration
+        {
+            LogAndStateDirectory = baseDirectory,
+            LogFileFormat = LogFileFormat.Json,
+            Jobs = Array.Empty<BackupJob>(),
+            LastFullBackupUtcByJobId = new Dictionary<int, DateTime>()
+        };
+    }
+}

--- a/src/EasySave.Gui/Services/FolderPickerService.cs
+++ b/src/EasySave.Gui/Services/FolderPickerService.cs
@@ -1,0 +1,38 @@
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+
+namespace EasySave.Gui.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IFolderPickerService"/> using
+/// Avalonia's <see cref="IStorageProvider"/> to display a native folder picker dialog.
+/// </summary>
+public sealed class FolderPickerService : IFolderPickerService
+{
+    private Window? _owner;
+
+    /// <inheritdoc />
+    public void SetOwner(Window? window)
+    {
+        _owner = window;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> PickFolderAsync(string? title = null)
+    {
+        if (_owner == null)
+            return null;
+
+        var folders = await _owner.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = title ?? "Select folder",
+            AllowMultiple = false
+        }).ConfigureAwait(true);
+
+        if (folders.Count == 0)
+            return null;
+
+        var path = folders[0].TryGetLocalPath();
+        return path;
+    }
+}

--- a/src/EasySave.Gui/Services/IConfigurationHolder.cs
+++ b/src/EasySave.Gui/Services/IConfigurationHolder.cs
@@ -1,0 +1,33 @@
+using EasySave.Core.Entities;
+
+namespace EasySave.Gui.Services;
+
+/// <summary>
+/// Holds the current backup configuration in memory as a single source of truth,
+/// shared across all tabs for smooth navigation without reloading from disk.
+/// </summary>
+public interface IConfigurationHolder
+{
+    /// <summary>
+    /// Current configuration instance shared by all tabs.
+    /// </summary>
+    BackupConfiguration Current { get; }
+
+    /// <summary>
+    /// Raised whenever the configuration has been reloaded or saved.
+    /// </summary>
+    event EventHandler? ConfigurationChanged;
+
+    /// <summary>
+    /// Reloads the configuration from the underlying repository.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+    Task ReloadAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persists the provided configuration and updates <see cref="Current"/>.
+    /// </summary>
+    /// <param name="configuration">Configuration to persist.</param>
+    /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+    Task SaveAsync(BackupConfiguration configuration, CancellationToken cancellationToken = default);
+}

--- a/src/EasySave.Gui/Services/IFolderPickerService.cs
+++ b/src/EasySave.Gui/Services/IFolderPickerService.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+
+namespace EasySave.Gui.Services;
+
+/// <summary>
+/// Service abstraction that opens a folder picker dialog (MVVM-friendly and testable).
+/// </summary>
+public interface IFolderPickerService
+{
+    /// <summary>
+    /// Sets the owner window for the dialog (should be called once at startup).
+    /// </summary>
+    /// <param name="window">Window that will own folder picker dialogs.</param>
+    void SetOwner(Window? window);
+
+    /// <summary>
+    /// Shows a folder picker dialog.
+    /// </summary>
+    /// <param name="title">Optional dialog title.</param>
+    /// <returns>The selected folder path, or <c>null</c> if the dialog is cancelled.</returns>
+    Task<string?> PickFolderAsync(string? title = null);
+}

--- a/src/EasySave.Gui/Services/ILocalizationProvider.cs
+++ b/src/EasySave.Gui/Services/ILocalizationProvider.cs
@@ -1,0 +1,28 @@
+namespace EasySave.Gui.Services;
+
+/// <summary>
+/// Provides localized UI strings for the GUI (inversion of control abstraction).
+/// </summary>
+public interface ILocalizationProvider
+{
+    /// <summary>
+    /// Gets a localized string for the given key using the current culture.
+    /// </summary>
+    string GetString(string key);
+
+    /// <summary>
+    /// Gets a formatted localized string for the given key.
+    /// </summary>
+    string GetString(string key, params object[] args);
+
+    /// <summary>
+    /// Raised when the culture changes so that bindings can refresh.
+    /// </summary>
+    event EventHandler? CultureChanged;
+
+    /// <summary>
+    /// Sets the UI culture (e.g. <c>"fr"</c>, <c>"en"</c>).
+    /// </summary>
+    /// <param name="cultureCode">Culture code to apply.</param>
+    void SetCulture(string cultureCode);
+}

--- a/src/EasySave.Gui/Services/LocalizationProvider.cs
+++ b/src/EasySave.Gui/Services/LocalizationProvider.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+using System.Resources;
+using System.Reflection;
+
+namespace EasySave.Gui.Services;
+
+/// <summary>
+/// Default implementation of <see cref="ILocalizationProvider"/> using
+/// strongly-typed access to ResX resources embedded in the GUI assembly.
+/// </summary>
+public sealed class LocalizationProvider : ILocalizationProvider
+{
+    private readonly ResourceManager _resourceManager;
+    private CultureInfo _currentCulture;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalizationProvider"/> class.
+    /// </summary>
+    public LocalizationProvider()
+    {
+        _resourceManager = new ResourceManager("EasySave.Gui.Resources.Strings", Assembly.GetExecutingAssembly());
+        _currentCulture = CultureInfo.CurrentUICulture;
+    }
+
+    public string GetString(string key)
+    {
+        var value = _resourceManager.GetString(key, _currentCulture);
+        return value ?? key;
+    }
+
+    public string GetString(string key, params object[] args)
+    {
+        var format = GetString(key);
+        return args.Length > 0 ? string.Format(format, args) : format;
+    }
+
+    public event EventHandler? CultureChanged;
+
+    public void SetCulture(string cultureCode)
+    {
+        _currentCulture = CultureInfo.GetCultureInfo(cultureCode);
+        CultureInfo.CurrentCulture = _currentCulture;
+        CultureInfo.CurrentUICulture = _currentCulture;
+        CultureInfo.DefaultThreadCurrentCulture = _currentCulture;
+        CultureInfo.DefaultThreadCurrentUICulture = _currentCulture;
+        CultureChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/EasySave.Gui/ViewModels/CreateEditJobViewModel.cs
+++ b/src/EasySave.Gui/ViewModels/CreateEditJobViewModel.cs
@@ -1,0 +1,242 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EasySave.Core.Entities;
+using EasySave.Core.Enums;
+using EasySave.Gui.Services;
+
+namespace EasySave.Gui.ViewModels;
+
+/// <summary>
+/// ViewModel for the create/edit tab: allows creating a new job
+/// or editing an existing one through a form.
+/// </summary>
+public sealed class CreateEditJobViewModel : ViewModelBase
+{
+    private readonly IConfigurationHolder _configHolder;
+    private readonly ILocalizationProvider _localization;
+    private readonly IFolderPickerService _folderPicker;
+    private JobItemViewModel? _selectedExistingJob;
+    private string _name = string.Empty;
+    private string _sourcePath = string.Empty;
+    private string _targetPath = string.Empty;
+    private int _selectedTypeIndex;
+    private string _excludeExtensions = string.Empty;
+    private string _excludeDirectories = string.Empty;
+    private string _statusText = string.Empty;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateEditJobViewModel"/> class.
+    /// </summary>
+    /// <param name="configHolder">Configuration holder providing current jobs and persistence.</param>
+    /// <param name="localization">Localization provider for UI strings.</param>
+    /// <param name="folderPicker">Service used to pick source and target folders.</param>
+    public CreateEditJobViewModel(IConfigurationHolder configHolder, ILocalizationProvider localization, IFolderPickerService folderPicker)
+    {
+        _configHolder = configHolder;
+        _localization = localization;
+        _folderPicker = folderPicker;
+        ExistingJobs = new ObservableCollection<JobItemViewModel>();
+        _configHolder.ConfigurationChanged += (_, _) => RefreshExistingJobs();
+        _localization.CultureChanged += (_, _) => RaiseLocalizedProperties();
+        RefreshExistingJobs();
+    }
+
+    private void RaiseLocalizedProperties()
+    {
+        RaisePropertyChanged(nameof(ExistingJobLabel));
+        RaisePropertyChanged(nameof(NewJobButtonText));
+        RaisePropertyChanged(nameof(EditHintText));
+        RaisePropertyChanged(nameof(LabelName));
+        RaisePropertyChanged(nameof(LabelSource));
+        RaisePropertyChanged(nameof(LabelTarget));
+        RaisePropertyChanged(nameof(LabelType));
+        RaisePropertyChanged(nameof(LabelExcludeExtensions));
+        RaisePropertyChanged(nameof(LabelExcludeDirs));
+        RaisePropertyChanged(nameof(SaveButtonText));
+        RaisePropertyChanged(nameof(FullBackupLabel));
+        RaisePropertyChanged(nameof(DifferentialBackupLabel));
+        RaisePropertyChanged(nameof(BrowseButtonText));
+    }
+
+    public string BrowseButtonText => _localization.GetString("Gui_Browse");
+
+    public ObservableCollection<JobItemViewModel> ExistingJobs { get; }
+
+    public JobItemViewModel? SelectedExistingJob
+    {
+        get => _selectedExistingJob;
+        set
+        {
+            if (SetProperty(ref _selectedExistingJob, value))
+                LoadJobIntoForm();
+        }
+    }
+
+    public string Name { get => _name; set => SetProperty(ref _name, value ?? string.Empty); }
+    public string SourcePath { get => _sourcePath; set => SetProperty(ref _sourcePath, value ?? string.Empty); }
+    public string TargetPath { get => _targetPath; set => SetProperty(ref _targetPath, value ?? string.Empty); }
+    public int SelectedTypeIndex { get => _selectedTypeIndex; set => SetProperty(ref _selectedTypeIndex, value); }
+    public string ExcludeExtensions { get => _excludeExtensions; set => SetProperty(ref _excludeExtensions, value ?? string.Empty); }
+    public string ExcludeDirectories { get => _excludeDirectories; set => SetProperty(ref _excludeDirectories, value ?? string.Empty); }
+    public string StatusText { get => _statusText; set => SetProperty(ref _statusText, value); }
+
+    public bool IsEditing => SelectedExistingJob != null;
+    public string ExistingJobLabel => _localization.GetString("Gui_ExistingJob");
+    public string NewJobButtonText => _localization.GetString("Gui_NewJob");
+    public string EditHintText => _localization.GetString("Gui_EditHint");
+    public string LabelName => _localization.GetString("Gui_LabelName");
+    public string LabelSource => _localization.GetString("Gui_LabelSource");
+    public string LabelTarget => _localization.GetString("Gui_LabelTarget");
+    public string LabelType => _localization.GetString("Gui_LabelType");
+    public string LabelExcludeExtensions => _localization.GetString("Gui_LabelExcludeExtensions");
+    public string LabelExcludeDirs => _localization.GetString("Gui_LabelExcludeDirs");
+    public string SaveButtonText => _localization.GetString("Gui_Save");
+    public string FullBackupLabel => _localization.GetString("FullBackup");
+    public string DifferentialBackupLabel => _localization.GetString("DifferentialBackup");
+
+    internal void RefreshExistingJobs()
+    {
+        ExistingJobs.Clear();
+        foreach (var j in _configHolder.Current.Jobs.OrderBy(x => x.Id))
+            ExistingJobs.Add(new JobItemViewModel(j.Id, j.Name, j.Type));
+    }
+
+    public void NewJob(object _)
+    {
+        SelectedExistingJob = null;
+        Name = string.Empty;
+        SourcePath = string.Empty;
+        TargetPath = string.Empty;
+        SelectedTypeIndex = 0;
+        ExcludeExtensions = string.Empty;
+        ExcludeDirectories = string.Empty;
+        StatusText = _localization.GetString("Gui_EditModeCreate");
+    }
+
+    public bool CanNewJob(object _) => true;
+
+    public async void PickSourceFolder(object _)
+    {
+        var path = await _folderPicker.PickFolderAsync(_localization.GetString("Gui_PickSourceFolder")).ConfigureAwait(true);
+        if (!string.IsNullOrEmpty(path))
+            SourcePath = path;
+    }
+
+    public bool CanPickSourceFolder(object _) => true;
+
+    public async void PickTargetFolder(object _)
+    {
+        var path = await _folderPicker.PickFolderAsync(_localization.GetString("Gui_PickTargetFolder")).ConfigureAwait(true);
+        if (!string.IsNullOrEmpty(path))
+            TargetPath = path;
+    }
+
+    public bool CanPickTargetFolder(object _) => true;
+
+    private void LoadJobIntoForm()
+    {
+        if (SelectedExistingJob == null)
+            return;
+        var job = _configHolder.Current.Jobs.FirstOrDefault(j => j.Id == SelectedExistingJob.Id);
+        if (job == null)
+            return;
+        Name = job.Name;
+        SourcePath = job.SourcePath;
+        TargetPath = job.TargetPath;
+        SelectedTypeIndex = job.Type == BackupType.Differential ? 1 : 0;
+        ExcludeExtensions = string.Join(",", job.ExcludeExtensions ?? Array.Empty<string>());
+        ExcludeDirectories = string.Join(",", job.ExcludeDirectoryNames ?? Array.Empty<string>());
+        StatusText = _localization.GetString("Gui_EditModeEdit", job.Id);
+    }
+
+    public async void SaveJob(object _)
+    {
+        var name = Name.Trim();
+        var source = SourcePath.Trim();
+        var target = TargetPath.Trim();
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(source) || string.IsNullOrEmpty(target))
+        {
+            StatusText = _localization.GetString("Gui_RequiredFields");
+            return;
+        }
+
+        var type = SelectedTypeIndex == 1 ? BackupType.Differential : BackupType.Full;
+        var excludeExt = ParseList(ExcludeExtensions);
+        var excludeDirs = ParseList(ExcludeDirectories);
+        var config = _configHolder.Current;
+        var jobs = config.Jobs.ToList();
+
+        if (SelectedExistingJob == null)
+        {
+            if (jobs.Count >= 5)
+            {
+                StatusText = _localization.GetString("MaxJobsReached");
+                return;
+            }
+            int newId = jobs.Count > 0 ? jobs.Max(j => j.Id) + 1 : 1;
+            if (newId > 5)
+            {
+                StatusText = _localization.GetString("Gui_MaxJobsDeleteOne");
+                return;
+            }
+            jobs.Add(new BackupJob
+            {
+                Id = newId,
+                Name = name,
+                SourcePath = source,
+                TargetPath = target,
+                Type = type,
+                ExcludeExtensions = excludeExt,
+                ExcludeDirectoryNames = excludeDirs
+            });
+            var newConfig = new BackupConfiguration
+            {
+                LogAndStateDirectory = config.LogAndStateDirectory,
+                LogFileFormat = config.LogFileFormat,
+                Jobs = jobs,
+                LastFullBackupUtcByJobId = config.LastFullBackupUtcByJobId
+            };
+            await _configHolder.SaveAsync(newConfig, CancellationToken.None).ConfigureAwait(true);
+            StatusText = _localization.GetString("JobCreated", newId);
+            NewJob(null!);
+            return;
+        }
+
+        int editId = SelectedExistingJob.Id;
+        var updated = new BackupJob
+        {
+            Id = editId,
+            Name = name,
+            SourcePath = source,
+            TargetPath = target,
+            Type = type,
+            ExcludeExtensions = excludeExt,
+            ExcludeDirectoryNames = excludeDirs
+        };
+        var replaced = jobs.Select(j => j.Id == editId ? updated : j).ToList();
+        var updatedConfig = new BackupConfiguration
+        {
+            LogAndStateDirectory = config.LogAndStateDirectory,
+            LogFileFormat = config.LogFileFormat,
+            Jobs = replaced,
+            LastFullBackupUtcByJobId = config.LastFullBackupUtcByJobId
+        };
+        await _configHolder.SaveAsync(updatedConfig, CancellationToken.None).ConfigureAwait(true);
+        StatusText = _localization.GetString("TuiJobUpdated", editId);
+    }
+
+    public bool CanSaveJob(object _) => true;
+
+    private static List<string> ParseList(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return new List<string>();
+        return raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/src/EasySave.Gui/ViewModels/JobItemViewModel.cs
+++ b/src/EasySave.Gui/ViewModels/JobItemViewModel.cs
@@ -1,0 +1,42 @@
+using EasySave.Core.Enums;
+
+namespace EasySave.Gui.ViewModels;
+
+/// <summary>
+/// Lightweight view model used to display a backup job in lists
+/// (separating presentation from domain entities).
+/// </summary>
+public sealed class JobItemViewModel : ViewModelBase
+{
+    private string _displayText = string.Empty;
+
+    /// <summary>Identifier of the backup job.</summary>
+    public int Id { get; }
+    /// <summary>Name of the backup job.</summary>
+    public string Name { get; }
+    /// <summary>Backup type (Full or Differential).</summary>
+    public BackupType Type { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JobItemViewModel"/> class.
+    /// </summary>
+    /// <param name="id">Job identifier.</param>
+    /// <param name="name">Job name.</param>
+    /// <param name="type">Job backup type.</param>
+    public JobItemViewModel(int id, string name, BackupType type)
+    {
+        Id = id;
+        Name = name;
+        Type = type;
+        _displayText = $"{Id} - {Name} ({Type})";
+    }
+
+    public string DisplayText
+    {
+        get => _displayText;
+        set => SetProperty(ref _displayText, value);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => DisplayText;
+}

--- a/src/EasySave.Gui/ViewModels/JobsTabViewModel.cs
+++ b/src/EasySave.Gui/ViewModels/JobsTabViewModel.cs
@@ -1,0 +1,191 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EasySave.Core.Entities;
+using EasySave.Core.Enums;
+using EasySave.Core.Interfaces;
+using EasySave.Gui.Services;
+
+namespace EasySave.Gui.ViewModels;
+
+/// <summary>
+/// ViewModel for the jobs tab: listing, details and execution of backup jobs.
+/// </summary>
+public sealed class JobsTabViewModel : ViewModelBase
+{
+    private readonly IConfigurationHolder _configHolder;
+    private readonly IBackupExecutor _backupExecutor;
+    private readonly ILocalizationProvider _localization;
+    private JobItemViewModel? _selectedJob;
+    private string _jobDetailsText = string.Empty;
+    private string _statusText = string.Empty;
+    private bool _isRunning;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JobsTabViewModel"/> class.
+    /// </summary>
+    /// <param name="configHolder">Configuration holder providing the current jobs.</param>
+    /// <param name="backupExecutor">Executor used to run backup jobs.</param>
+    /// <param name="localization">Localization provider for UI strings.</param>
+    public JobsTabViewModel(
+        IConfigurationHolder configHolder,
+        IBackupExecutor backupExecutor,
+        ILocalizationProvider localization)
+    {
+        _configHolder = configHolder;
+        _backupExecutor = backupExecutor;
+        _localization = localization;
+        Jobs = new ObservableCollection<JobItemViewModel>();
+        _configHolder.ConfigurationChanged += (_, _) => RefreshJobsFromConfig();
+        _localization.CultureChanged += (_, _) => RaiseLocalizedProperties();
+        RefreshJobsFromConfig();
+    }
+
+    private void RaiseLocalizedProperties()
+    {
+        RaisePropertyChanged(nameof(JobsListTitle));
+        RaisePropertyChanged(nameof(DetailsTitle));
+        RaisePropertyChanged(nameof(RefreshButtonText));
+        RaisePropertyChanged(nameof(RunSelectedButtonText));
+        RaisePropertyChanged(nameof(JobsHintText));
+    }
+
+    public ObservableCollection<JobItemViewModel> Jobs { get; }
+
+    public JobItemViewModel? SelectedJob
+    {
+        get => _selectedJob;
+        set
+        {
+        if (SetProperty(ref _selectedJob, value))
+        {
+            UpdateDetails();
+            RaisePropertyChanged(nameof(CanRunSelected));
+        }
+    }
+    }
+
+    public string JobDetailsText
+    {
+        get => _jobDetailsText;
+        set => SetProperty(ref _jobDetailsText, value);
+    }
+
+    public string StatusText
+    {
+        get => _statusText;
+        set => SetProperty(ref _statusText, value);
+    }
+
+    public bool IsRunning
+    {
+        get => _isRunning;
+        set => SetProperty(ref _isRunning, value);
+    }
+
+    public string JobsListTitle => _localization.GetString("Gui_JobsListTitle");
+    public string DetailsTitle => _localization.GetString("Gui_DetailsTitle");
+    public string RefreshButtonText => _localization.GetString("Gui_Refresh");
+    public string RunSelectedButtonText => _localization.GetString("Gui_RunSelected");
+    public string JobsHintText => _localization.GetString("Gui_JobsHint");
+
+    public bool CanRefresh => !IsRunning;
+
+    public void Refresh(object _)
+    {
+        _ = RefreshAsync();
+    }
+
+    private async Task RefreshAsync()
+    {
+        IsRunning = true;
+        try
+        {
+            await _configHolder.ReloadAsync(CancellationToken.None).ConfigureAwait(true);
+            StatusText = _localization.GetString("Gui_JobsRefreshed");
+        }
+        finally
+        {
+            IsRunning = false;
+            RaisePropertyChanged(nameof(CanRefresh));
+            RaisePropertyChanged(nameof(CanRunSelected));
+        }
+    }
+
+    public bool CanRunSelected => SelectedJob != null && !IsRunning;
+
+    public async void RunSelected(object _)
+    {
+        if (SelectedJob == null)
+        {
+            StatusText = _localization.GetString("Gui_SelectJobFirst");
+            return;
+        }
+
+        IsRunning = true;
+        StatusText = _localization.GetString("Gui_JobRunning", SelectedJob.Id);
+        try
+        {
+            await _backupExecutor.ExecuteAsync(
+                new[] { SelectedJob.Id },
+                progress: null,
+                CancellationToken.None).ConfigureAwait(true);
+            StatusText = _localization.GetString("Gui_JobSuccess", SelectedJob.Id);
+        }
+        catch (Exception ex)
+        {
+            StatusText = _localization.GetString("Gui_JobError", ex.Message);
+        }
+        finally
+        {
+            IsRunning = false;
+            RaisePropertyChanged(nameof(CanRefresh));
+        }
+    }
+
+    internal void RefreshJobsFromConfig()
+    {
+        var config = _configHolder.Current;
+        Jobs.Clear();
+        foreach (var j in config.Jobs.OrderBy(x => x.Id))
+            Jobs.Add(new JobItemViewModel(j.Id, j.Name, j.Type));
+
+        if (Jobs.Count > 0 && SelectedJob == null)
+            SelectedJob = Jobs[0];
+        else if (SelectedJob != null)
+        {
+            var stillSelected = Jobs.FirstOrDefault(x => x.Id == SelectedJob.Id);
+            SelectedJob = stillSelected;
+        }
+
+        if (Jobs.Count == 0)
+            JobDetailsText = _localization.GetString("NoJobsFound");
+        else
+            UpdateDetails();
+        RaisePropertyChanged(nameof(CanRunSelected));
+    }
+
+    private void UpdateDetails()
+    {
+        if (SelectedJob == null)
+            return;
+        var config = _configHolder.Current;
+        var job = config.Jobs.FirstOrDefault(j => j.Id == SelectedJob.Id);
+        if (job == null)
+            return;
+
+        var typeStr = job.Type == BackupType.Differential
+            ? _localization.GetString("DifferentialBackup")
+            : _localization.GetString("FullBackup");
+        JobDetailsText = string.Format(
+            _localization.GetString("Gui_JobDetailsFormat"),
+            job.Id,
+            job.Name,
+            typeStr,
+            job.SourcePath,
+            job.TargetPath,
+            string.Join(", ", job.ExcludeExtensions ?? Array.Empty<string>()),
+            string.Join(", ", job.ExcludeDirectoryNames ?? Array.Empty<string>()));
+    }
+}

--- a/src/EasySave.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/EasySave.Gui/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,54 @@
+using EasySave.Gui.Services;
+
+namespace EasySave.Gui.ViewModels;
+
+/// <summary>
+/// ViewModel for the main window: header texts and tab view models.
+/// Contains orchestration logic only, no business rules.
+/// </summary>
+public sealed class MainWindowViewModel : ViewModelBase
+{
+    private readonly ILocalizationProvider _localization;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainWindowViewModel"/> class.
+    /// </summary>
+    /// <param name="localization">Localization provider used to retrieve UI strings.</param>
+    /// <param name="jobsTab">ViewModel for the jobs tab.</param>
+    /// <param name="createEditTab">ViewModel for the create/edit tab.</param>
+    /// <param name="settingsTab">ViewModel for the settings tab.</param>
+    public MainWindowViewModel(
+        ILocalizationProvider localization,
+        JobsTabViewModel jobsTab,
+        CreateEditJobViewModel createEditTab,
+        SettingsViewModel settingsTab)
+    {
+        _localization = localization;
+        JobsTab = jobsTab;
+        CreateEditTab = createEditTab;
+        SettingsTab = settingsTab;
+        _localization.CultureChanged += (_, _) => RaiseHeaderProperties();
+    }
+
+    /// <summary>ViewModel for the jobs tab.</summary>
+    public JobsTabViewModel JobsTab { get; }
+    /// <summary>ViewModel for the create/edit tab.</summary>
+    public CreateEditJobViewModel CreateEditTab { get; }
+    /// <summary>ViewModel for the settings tab.</summary>
+    public SettingsViewModel SettingsTab { get; }
+
+    public string WindowTitle => _localization.GetString("Gui_WindowTitle");
+    public string HeaderTitle => _localization.GetString("Gui_HeaderTitle");
+    public string TabJobs => _localization.GetString("Gui_TabJobs");
+    public string TabCreateEdit => _localization.GetString("Gui_TabCreateEdit");
+    public string TabSettings => _localization.GetString("Gui_TabSettings");
+
+    private void RaiseHeaderProperties()
+    {
+        RaisePropertyChanged(nameof(WindowTitle));
+        RaisePropertyChanged(nameof(HeaderTitle));
+        RaisePropertyChanged(nameof(TabJobs));
+        RaisePropertyChanged(nameof(TabCreateEdit));
+        RaisePropertyChanged(nameof(TabSettings));
+    }
+}

--- a/src/EasySave.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/EasySave.Gui/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,89 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EasySave.Core.Entities;
+using EasySave.Core.Enums;
+using EasySave.Gui.Services;
+
+namespace EasySave.Gui.ViewModels;
+
+/// <summary>
+/// ViewModel for the settings tab: shows the important paths
+/// and allows changing the log format.
+/// </summary>
+public sealed class SettingsViewModel : ViewModelBase
+{
+    private readonly IConfigurationHolder _configHolder;
+    private readonly ILocalizationProvider _localization;
+    private readonly EasySavePaths _paths;
+    private int _logFormatIndex;
+    private string _statusText = string.Empty;
+
+    public SettingsViewModel(
+        IConfigurationHolder configHolder,
+        ILocalizationProvider localization,
+        EasySavePaths paths)
+    {
+        _configHolder = configHolder;
+        _localization = localization;
+        _paths = paths;
+        _configHolder.ConfigurationChanged += (_, _) => SyncFromConfig();
+        _localization.CultureChanged += (_, _) => RaiseLocalizedProperties();
+        SyncFromConfig();
+    }
+
+    private void RaiseLocalizedProperties()
+    {
+        RaisePropertyChanged(nameof(LabelBasePath));
+        RaisePropertyChanged(nameof(LabelConfigPath));
+        RaisePropertyChanged(nameof(LabelStatePath));
+        RaisePropertyChanged(nameof(LabelLogDir));
+        RaisePropertyChanged(nameof(LabelLogFormat));
+        RaisePropertyChanged(nameof(SaveSettingsButtonText));
+    }
+
+    public string BasePath => _paths.BaseDirectory;
+    public string ConfigPath => _paths.ConfigFilePath;
+    public string StatePath => _paths.StateFilePath;
+    public string LogDirectory => _paths.LogDirectory;
+
+    public int LogFormatIndex
+    {
+        get => _logFormatIndex;
+        set => SetProperty(ref _logFormatIndex, value);
+    }
+
+    public string StatusText
+    {
+        get => _statusText;
+        set => SetProperty(ref _statusText, value);
+    }
+
+    public string LabelBasePath => _localization.GetString("Gui_LabelBasePath");
+    public string LabelConfigPath => _localization.GetString("Gui_LabelConfigPath");
+    public string LabelStatePath => _localization.GetString("Gui_LabelStatePath");
+    public string LabelLogDir => _localization.GetString("Gui_LabelLogDir");
+    public string LabelLogFormat => _localization.GetString("Gui_LabelLogFormat");
+    public string SaveSettingsButtonText => _localization.GetString("Gui_SaveSettings");
+
+    internal void SyncFromConfig()
+    {
+        LogFormatIndex = _configHolder.Current.LogFileFormat == LogFileFormat.Xml ? 1 : 0;
+    }
+
+    public async void SaveSettings(object _)
+    {
+        var format = LogFormatIndex == 1 ? LogFileFormat.Xml : LogFileFormat.Json;
+        var config = _configHolder.Current;
+        var updated = new BackupConfiguration
+        {
+            LogAndStateDirectory = config.LogAndStateDirectory,
+            LogFileFormat = format,
+            Jobs = config.Jobs,
+            LastFullBackupUtcByJobId = config.LastFullBackupUtcByJobId
+        };
+        await _configHolder.SaveAsync(updated, CancellationToken.None).ConfigureAwait(true);
+        StatusText = _localization.GetString("Gui_SettingsSaved", format.ToString());
+    }
+
+    public bool CanSaveSettings(object _) => true;
+}

--- a/src/EasySave.Gui/ViewModels/ViewModelBase.cs
+++ b/src/EasySave.Gui/ViewModels/ViewModelBase.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace EasySave.Gui.ViewModels;
+
+/// <summary>
+/// Base class for all ViewModels providing property change notification (MVVM).
+/// </summary>
+public abstract class ViewModelBase : INotifyPropertyChanged
+{
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    /// <summary>
+    /// Raises a <see cref="PropertyChanged"/> event for the given property.
+    /// </summary>
+    /// <param name="propertyName">Name of the changed property.</param>
+    protected void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    /// <summary>
+    /// Sets a backing field and raises a <see cref="PropertyChanged"/> event
+    /// if the value has changed.
+    /// </summary>
+    /// <typeparam name="T">Type of the property.</typeparam>
+    /// <param name="field">Reference to the backing field.</param>
+    /// <param name="value">New value to apply.</param>
+    /// <param name="propertyName">Name of the changed property.</param>
+    /// <returns><c>true</c> if the value changed; otherwise <c>false</c>.</returns>
+    protected bool SetProperty<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+            return false;
+        field = value;
+        RaisePropertyChanged(propertyName);
+        return true;
+    }
+}


### PR DESCRIPTION
## Description

Ajoute un nouveau projet d'interface graphique basé sur Avalonia (`EasySave.Gui`) permettant de lancer EasySave en mode graphique avec une navigation claire entre les pages.

**Fenêtre principale**

- En-tête avec logo et titre..
- Trois onglets : **Tâches**, **Créer/Modifier**, **Paramètres**.
- Navigation entre les onglets sans rechargement de la configuration (configuration en mémoire via `IConfigurationHolder`).

**Implémentation**

- **MVVM** : ViewModels par onglet (`JobsTabViewModel`, `CreateEditJobViewModel`, `SettingsViewModel`), `ViewModelBase` avec `INotifyPropertyChanged`.
- **SOLID** : Services sous interfaces (`ILocalizationProvider`, `IConfigurationHolder`, `IFolderPickerService`), injection de dépendances dans `CompositionRoot`.
- **Internationalisation** : Ressources ResX (`Resources/Strings.resx`, `Resources/Strings.fr.resx`) et `ILocalizationProvider` pour les chaînes de caractères de l'interface utilisateur ; les liaisons sont actualisées lors d'un changement de langue.
- **FluentAvalonia** pour un thème clair moderne ; sélecteur de répertoires pour les chemins source/cible dans les modes Créer/Modifier.
- **Documentation** : Tous les commentaires C# et la documentation XML du projet d'interface graphique sont en anglais.

Le mode console reste inchangé : le projet `EasySave.Console` existant demeure le point d'entrée par défaut ; l'interface graphique s'exécute via `dotnet run --project src/EasySave.Gui/EasySave.Gui.csproj`.


## Liens vers les issues

- Closes #137 
- Closes #138 
- Closes #139 
- Closes #143 

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [x] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [x] Le comportement a été vérifié manuellement (si applicable)
- [x] La documentation / README / commentaires sont à jour
- [x] Pas de fichiers temporaires ou de debug dans le diff
