### PR TITLE
feat: manage async logs 

### DIFF
--- a/src/EasyLog/DailyLogWriter.cs
+++ b/src/EasyLog/DailyLogWriter.cs
@@ -27,7 +27,7 @@ namespace EasyLog
         /// Writes the specified log entry asynchronously to a daily log file in JSON array format.
         /// The file name is determined from UTC date (format: yyyy-MM-dd.json).
         /// </summary>
-        public async Task WriteAsync<T>(T logEntry, CancellationToken cancellationToken)
+        public async Task WriteAllTextAsync<T>(T logEntry, CancellationToken cancellationToken)
         {
             var logFilePath = Path.Combine(_baseDirectory, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
             Directory.CreateDirectory(_baseDirectory);
@@ -37,22 +37,8 @@ namespace EasyLog
             await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                string existing = string.Empty;
-                if (File.Exists(logFilePath))
-                {
-                    using var fs = new FileStream(logFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true);
-                    using var mem = new MemoryStream();
-                    byte[] buffer = new byte[81920];
-                    int read;
-                    while ((read = await fs.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false)) > 0)
-                    {
-                        mem.Write(buffer, 0, read);
-                    }
-
-                    var bytes = mem.ToArray();
-                    existing = Encoding.UTF8.GetString(bytes);
-                }
-
+                var existing = File.Exists(logFilePath) ? await Task.Run(() => File.ReadAllText(logFilePath, Encoding.UTF8), cancellationToken).ConfigureAwait(false) : string.Empty;
+                
                 var trimmed = existing.TrimEnd();
                 var trailing = existing.Length > trimmed.Length ? existing.Substring(trimmed.Length) : string.Empty;
 
@@ -67,9 +53,7 @@ namespace EasyLog
                         : trimmed + "," + json + "]" + trailing;
                 }
 
-                var outBytes = Encoding.UTF8.GetBytes(newContent);
-                using var writeFs = new FileStream(logFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 4096, useAsync: true);
-                await writeFs.WriteAsync(outBytes, 0, outBytes.Length, cancellationToken).ConfigureAwait(false);
+                await Task.Run(() => File.WriteAllText(logFilePath, newContent, Encoding.UTF8), cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -80,9 +64,9 @@ namespace EasyLog
         /// <summary>
         /// Compatibility overload: write without providing a CancellationToken.
         /// </summary>
-        public Task WriteAsync<T>(T logEntry)
+        public Task WriteAllTextAsync<T>(T logEntry)
         {
-            return WriteAsync<T>(logEntry, CancellationToken.None);
+            return WriteAllTextAsync<T>(logEntry, CancellationToken.None);
         }
 
         /// <summary>

--- a/src/EasyLog/ILogWriter.cs
+++ b/src/EasyLog/ILogWriter.cs
@@ -16,6 +16,6 @@ namespace EasyLog
         /// <param name="logEntry">The log entry to write.</param>
         /// <param name="cancellationToken">Cancellation token to cancel the operation if required.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task WriteAsync<T>(T logEntry, CancellationToken cancellationToken);
+        Task WriteAllTextAsync<T>(T logEntry, CancellationToken cancellationToken);
     }
 }

--- a/src/EasyLog/XmlDailyLogWriter.cs
+++ b/src/EasyLog/XmlDailyLogWriter.cs
@@ -17,7 +17,7 @@ namespace EasyLog
             _baseDirectory = baseDirectory ?? throw new ArgumentNullException(nameof(baseDirectory));
         }
 
-        public async Task WriteAsync<T>(T logEntry, CancellationToken cancellationToken)
+        public async Task WriteAllTextAsync<T>(T logEntry, CancellationToken cancellationToken)
         {
             string logFilePath = Path.Combine(_baseDirectory, $"{DateTime.UtcNow:yyyy-MM-dd}.xml");
             Directory.CreateDirectory(_baseDirectory);
@@ -65,9 +65,9 @@ namespace EasyLog
         /// <summary>
         /// Compatibility overload: write without providing a CancellationToken.
         /// </summary>
-        public Task WriteAsync<T>(T logEntry)
+        public Task WriteAllTextAsync<T>(T logEntry)
         {
-            return WriteAsync<T>(logEntry, CancellationToken.None);
+            return WriteAllTextAsync<T>(logEntry, CancellationToken.None);
         }
 
         private static XElement CreateLogEntryElement<T>(T logEntry)

--- a/src/EasySave.Infrastructure/Backup/BackupExecutor.cs
+++ b/src/EasySave.Infrastructure/Backup/BackupExecutor.cs
@@ -384,7 +384,7 @@ namespace EasySave.Infrastructure.Backup
                 };
                 await WriteStateAndReportAsync(progressList, idx, progress, cancellationToken).ConfigureAwait(false);
                 LogEntry stopEntry = new LogEntry(DateTime.UtcNow, job.Name, "", "", 0, TimeSpan.Zero, 0, reason: StopReasonUserRequested);
-                await _logWriter.WriteAsync(stopEntry, cancellationToken).ConfigureAwait(false);
+                await _logWriter.WriteAllTextAsync(stopEntry, cancellationToken).ConfigureAwait(false);
                 return true;
             }
 
@@ -496,7 +496,9 @@ namespace EasySave.Infrastructure.Backup
                 }
 
                 TimeSpan transferTime = TimeSpan.FromMilliseconds(Math.Abs(transferMs));
-                await _logWriter.WriteAsync(new LogEntry(DateTime.UtcNow, job.Name, uncSource, uncDest, fileSize, transferTime, encryptionTimeMs), cancellationToken).ConfigureAwait(false);
+                await _logWriter.WriteAllTextAsync(
+                    new LogEntry(DateTime.UtcNow, job.Name, uncSource, uncDest, fileSize, transferTime, encryptionTimeMs),
+                    cancellationToken).ConfigureAwait(false);
 
                 bytesCompleted += fileSize;
                 processedCount++;
@@ -551,7 +553,7 @@ namespace EasySave.Infrastructure.Backup
                         };
                         await WriteStateAndReportAsync(progressList, idx, progress, CancellationToken.None).ConfigureAwait(false);
                         LogEntry stopEntry = new LogEntry(DateTime.UtcNow, job.Name, "", "", 0, TimeSpan.Zero, 0, reason: StopReasonBusinessSoftware);
-                        await _logWriter.WriteAsync(stopEntry, CancellationToken.None).ConfigureAwait(false);
+                        await _logWriter.WriteAllTextAsync(stopEntry, CancellationToken.None).ConfigureAwait(false);
                         onBusinessSoftwareDetected?.Invoke();
                         return;
                     }
@@ -622,7 +624,7 @@ namespace EasySave.Infrastructure.Backup
                     0,
                     reason: $"StateOrProgressReportFailed ({ex.GetType().Name}): {ex.Message}"
                 );
-                await _logWriter.WriteAsync(errorEntry, CancellationToken.None).ConfigureAwait(false);
+                await _logWriter.WriteAllTextAsync(errorEntry, CancellationToken.None).ConfigureAwait(false);
             }
         }
     }

--- a/src/EasySave.Infrastructure/Persistence/ConfigurableLogWriter.cs
+++ b/src/EasySave.Infrastructure/Persistence/ConfigurableLogWriter.cs
@@ -28,7 +28,7 @@ namespace EasySave.Infrastructure.Persistence
             _xmlWriter = xmlWriter ?? throw new ArgumentNullException(nameof(xmlWriter));
         }
 
-        public async Task WriteAsync<T>(T logEntry, CancellationToken cancellationToken)
+        public async Task WriteAllTextAsync<T>(T logEntry, CancellationToken cancellationToken)
         {
             BackupConfiguration? config = await _configRepository.LoadAsync(cancellationToken).ConfigureAwait(false);
             LogFileFormat format = config?.LogFileFormat ?? LogFileFormat.Json;
@@ -36,11 +36,11 @@ namespace EasySave.Infrastructure.Persistence
             switch (format)
             {
                 case LogFileFormat.Xml:
-                    await _xmlWriter.WriteAsync(logEntry, cancellationToken).ConfigureAwait(false);
+                    await _xmlWriter.WriteAllTextAsync(logEntry, cancellationToken).ConfigureAwait(false);
                     break;
                 case LogFileFormat.Json:
                 default:
-                    await _jsonWriter.WriteAsync(logEntry, cancellationToken).ConfigureAwait(false);
+                    await _jsonWriter.WriteAllTextAsync(logEntry, cancellationToken).ConfigureAwait(false);
                     break;
             }
         }

--- a/src/EasySave.Infrastructure/Persistence/DestinationLogWriter.cs
+++ b/src/EasySave.Infrastructure/Persistence/DestinationLogWriter.cs
@@ -36,12 +36,12 @@ public sealed class DestinationLogWriter : ILogWriter
     }
 
     /// <inheritdoc />
-    public async Task WriteAsync<T>(T logEntry, CancellationToken cancellationToken)
+    public async Task WriteAllTextAsync<T>(T logEntry, CancellationToken cancellationToken)
     {
         LogRouting routing = await GetRoutingAsync(cancellationToken).ConfigureAwait(false);
 
         if (routing.WriteLocal)
-            await _localWriter.WriteAsync(logEntry, cancellationToken).ConfigureAwait(false);
+            await _localWriter.WriteAllTextAsync(logEntry, cancellationToken).ConfigureAwait(false);
 
         if (routing.SendCentral && logEntry is LogEntry entry)
             await _centralizedClient.SendAsync(entry, routing.ServerAddress, cancellationToken).ConfigureAwait(false);

--- a/src/EasySave.LogServer/Protocol/LogEntryHandler.cs
+++ b/src/EasySave.LogServer/Protocol/LogEntryHandler.cs
@@ -38,7 +38,7 @@ public sealed class LogEntryHandler : ILogEntryHandler
             dto.EncryptionTimeMs,
             dto.Reason);
 
-        await _logWriter.WriteAsync(entry, cancellationToken).ConfigureAwait(false);
+        await _logWriter.WriteAllTextAsync(entry, cancellationToken).ConfigureAwait(false);
         return true;
     }
 }

--- a/tests/EasyLog.Tests/DailyLogWriterTests.cs
+++ b/tests/EasyLog.Tests/DailyLogWriterTests.cs
@@ -31,7 +31,7 @@ public sealed class DailyLogWriterTests : IDisposable
     {
         var writer = new EasyLog.DailyLogWriter(_tempDir);
         var entry = new TestLogEntry(DateTime.UtcNow, "job1", "src", "dest", 123L, TimeSpan.FromMilliseconds(10));
-        await writer.WriteAsync(entry);
+        await writer.WriteAllTextAsync(entry);
 
         var file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.json");
         Assert.True(File.Exists(file));
@@ -56,7 +56,7 @@ public sealed class DailyLogWriterTests : IDisposable
 
         var writer = new EasyLog.DailyLogWriter(_tempDir);
         var entry = new TestLogEntry(DateTime.UtcNow, "appended", "src2", "dest2", 456L, TimeSpan.FromMilliseconds(20));
-        await writer.WriteAsync(entry);
+        await writer.WriteAllTextAsync(entry);
 
         var content = File.ReadAllText(file);
         using (var doc = JsonDocument.Parse(content))
@@ -75,7 +75,7 @@ public sealed class DailyLogWriterTests : IDisposable
 
         var writer = new EasyLog.DailyLogWriter(_tempDir);
         var entry = new TestLogEntry(DateTime.UtcNow, "onlyBracket", "s", "d", 2, TimeSpan.Zero);
-        await writer.WriteAsync(entry);
+        await writer.WriteAllTextAsync(entry);
 
         var content = File.ReadAllText(file);
         using (var doc = JsonDocument.Parse(content))
@@ -94,7 +94,7 @@ public sealed class DailyLogWriterTests : IDisposable
         var tasks = Enumerable.Range(0, n).Select(i =>
         {
             var entry = new TestLogEntry(DateTime.UtcNow, "job" + i, "s", "d", i, TimeSpan.FromMilliseconds(i));
-            return writer.WriteAsync(entry);
+            return writer.WriteAllTextAsync(entry);
         }).ToArray();
 
         await Task.WhenAll(tasks);

--- a/tests/EasyLog.Tests/XmlDailyLogWriterTests.cs
+++ b/tests/EasyLog.Tests/XmlDailyLogWriterTests.cs
@@ -32,7 +32,7 @@ public sealed class XmlDailyLogWriterTests : IDisposable
         var writer = new EasyLog.XmlDailyLogWriter(_tempDir);
         var entry = new TestLogEntry(DateTime.UtcNow, "job1", "src", "dest", 123L, TimeSpan.FromMilliseconds(10));
 
-        await writer.WriteAsync(entry, default);
+        await writer.WriteAllTextAsync(entry, default);
 
         string file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.xml");
         Assert.True(File.Exists(file));
@@ -52,8 +52,8 @@ public sealed class XmlDailyLogWriterTests : IDisposable
     {
         var writer = new EasyLog.XmlDailyLogWriter(_tempDir);
 
-        await writer.WriteAsync(new TestLogEntry(DateTime.UtcNow, "job1", "s1", "d1", 1, TimeSpan.FromMilliseconds(1)), default);
-        await writer.WriteAsync(new TestLogEntry(DateTime.UtcNow, "job2", "s2", "d2", 2, TimeSpan.FromMilliseconds(2)), default);
+        await writer.WriteAllTextAsync(new TestLogEntry(DateTime.UtcNow, "job1", "s1", "d1", 1, TimeSpan.FromMilliseconds(1)), default);
+        await writer.WriteAllTextAsync(new TestLogEntry(DateTime.UtcNow, "job2", "s2", "d2", 2, TimeSpan.FromMilliseconds(2)), default);
 
         string file = Path.Combine(_tempDir, $"{DateTime.UtcNow:yyyy-MM-dd}.xml");
         XDocument doc = XDocument.Load(file);

--- a/tests/EasySave.Infrastructure.Tests/BackupExecutorTests.cs
+++ b/tests/EasySave.Infrastructure.Tests/BackupExecutorTests.cs
@@ -649,7 +649,7 @@ namespace EasySave.Infrastructure.Tests;
     {
         public List<LogEntry> LogEntries { get; } = new();
 
-        public Task WriteAsync<T>(T logEntry, CancellationToken cancellationToken)
+        public Task WriteAllTextAsync<T>(T logEntry, CancellationToken cancellationToken)
         {
             if (logEntry is LogEntry entry)
             {


### PR DESCRIPTION
## Description

Les écritures de logs locaux (fichiers journaliers) doivent être réalisées en asynchrone ou en parallèle afin de ne pas bloquer le flux de sauvegarde et d’améliorer les performances.

## Liens vers les issues

- Closes #160

## Type de changement

- [x] Nouvelle feature
- [ ] Correction de bug
- [ ] Tâche technique / refactor
- [ ] Documentation

## Checklist (DoD)

- [x] Le code compile sans erreur
- [x] Les tests existants passent (`dotnet test`)
- [ ] De nouveaux tests ont été ajoutés / adaptés si nécessaire
- [ ] Le comportement a été vérifié manuellement (si applicable)
- [ ] La documentation / README / commentaires sont à jour
- [ ] Pas de fichiers temporaires ou de debug dans le diff
